### PR TITLE
fix: use bash defined in PATH in shebangs

### DIFF
--- a/rust/carbine_fedimint/build.sh
+++ b/rust/carbine_fedimint/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #cargo ndk -t arm64-v8a -t armeabi-v7a -t x86_64 -o ../../android/app/src/main/jniLibs build --release
 cargo build --release --target x86_64-unknown-linux-gnu

--- a/scripts/build-android.sh
+++ b/scripts/build-android.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cd $ROOT/rust/carbine_fedimint
 export CC_aarch64_linux_android=$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin/x86_64-linux-android21-clang

--- a/scripts/build-arm-android.sh
+++ b/scripts/build-arm-android.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cd $ROOT/rust/carbine_fedimint
 export CC_aarch64_linux_android=$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android21-clang

--- a/scripts/build-linux.sh
+++ b/scripts/build-linux.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 unset CC_aarch64_linux_android
 unset CXX_aarch64_linux_android


### PR DESCRIPTION
Using `#!/usr/bin/env bash` will look for the first instance of `bash` in `$PATH`, which makes these scripts more portable and uses `bash` defined in the `devShell`.