### PR TITLE
chore: format all dart files with `dart format`

### DIFF
--- a/lib/dashboard.dart
+++ b/lib/dashboard.dart
@@ -56,9 +56,10 @@ class _DashboardState extends State<Dashboard> {
   }
 
   void _onScroll() {
-    if (_scrollController.position.pixels >= _scrollController.position.maxScrollExtent - 100 &&
-      !_isFetchingMore &&
-      _hasMore) {
+    if (_scrollController.position.pixels >=
+            _scrollController.position.maxScrollExtent - 100 &&
+        !_isFetchingMore &&
+        _hasMore) {
       _loadTransactions(loadMore: true);
     }
   }
@@ -130,11 +131,18 @@ class _DashboardState extends State<Dashboard> {
     if (_selectedPaymentType == PaymentType.lightning) {
       //await Navigator.push(context, MaterialPageRoute(builder: (context) => ScanQRPage(selectedFed: widget.fed)));
       await showCarbineModalBottomSheet(
-        context: context, 
+        context: context,
         child: PaymentMethodSelector(fed: widget.fed),
       );
     } else if (_selectedPaymentType == PaymentType.ecash) {
-      await Navigator.push(context, MaterialPageRoute(builder: (context) => NumberPad(fed: widget.fed, paymentType: _selectedPaymentType)));
+      await Navigator.push(
+        context,
+        MaterialPageRoute(
+          builder:
+              (context) =>
+                  NumberPad(fed: widget.fed, paymentType: _selectedPaymentType),
+        ),
+      );
     }
     _loadBalance();
     _loadTransactions();
@@ -142,9 +150,21 @@ class _DashboardState extends State<Dashboard> {
 
   void _onReceivePressed() async {
     if (_selectedPaymentType == PaymentType.lightning) {
-      await Navigator.push(context, MaterialPageRoute(builder: (context) => NumberPad(fed: widget.fed, paymentType: _selectedPaymentType)));
+      await Navigator.push(
+        context,
+        MaterialPageRoute(
+          builder:
+              (context) =>
+                  NumberPad(fed: widget.fed, paymentType: _selectedPaymentType),
+        ),
+      );
     } else if (_selectedPaymentType == PaymentType.ecash) {
-      await Navigator.push(context, MaterialPageRoute(builder: (context) => ScanQRPage(selectedFed: widget.fed)));
+      await Navigator.push(
+        context,
+        MaterialPageRoute(
+          builder: (context) => ScanQRPage(selectedFed: widget.fed),
+        ),
+      );
     }
 
     _loadBalance();
@@ -177,7 +197,7 @@ class _DashboardState extends State<Dashboard> {
             backgroundColor: Colors.green,
             onTap: () => _scheduleAction(_onReceivePressed),
           ),
-          if (balanceMsats != null && balanceMsats! > BigInt.zero) 
+          if (balanceMsats != null && balanceMsats! > BigInt.zero)
             SpeedDialChild(
               child: const Icon(Icons.upload),
               label: 'Send',
@@ -193,30 +213,35 @@ class _DashboardState extends State<Dashboard> {
           children: [
             const SizedBox(height: 32),
             ShaderMask(
-              shaderCallback: (bounds) => LinearGradient(
-                colors: [
-                  Theme.of(context).colorScheme.primary,
-                  Theme.of(context).colorScheme.secondary
-                ],
-                begin: Alignment.topLeft,
-                end: Alignment.bottomRight,
-              ).createShader(Rect.fromLTWH(0, 0, bounds.width, bounds.height)),
+              shaderCallback:
+                  (bounds) => LinearGradient(
+                    colors: [
+                      Theme.of(context).colorScheme.primary,
+                      Theme.of(context).colorScheme.secondary,
+                    ],
+                    begin: Alignment.topLeft,
+                    end: Alignment.bottomRight,
+                  ).createShader(
+                    Rect.fromLTWH(0, 0, bounds.width, bounds.height),
+                  ),
               child: Column(
                 children: [
                   Text(
                     name.toUpperCase(),
                     style: Theme.of(context).textTheme.headlineMedium?.copyWith(
-                          fontWeight: FontWeight.w900,
-                          letterSpacing: 2,
-                          color: Colors.white,
-                          shadows: [
-                            Shadow(
-                              blurRadius: 10,
-                              color: Theme.of(context).colorScheme.primary.withOpacity(0.5),
-                              offset: const Offset(0, 2),
-                            ),
-                          ],
+                      fontWeight: FontWeight.w900,
+                      letterSpacing: 2,
+                      color: Colors.white,
+                      shadows: [
+                        Shadow(
+                          blurRadius: 10,
+                          color: Theme.of(
+                            context,
+                          ).colorScheme.primary.withOpacity(0.5),
+                          offset: const Offset(0, 2),
                         ),
+                      ],
+                    ),
                     textAlign: TextAlign.center,
                   ),
                   if (widget.fed.network.toLowerCase() != 'bitcoin')
@@ -225,9 +250,9 @@ class _DashboardState extends State<Dashboard> {
                       child: Text(
                         "This is a test network and is not worth anything.",
                         style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                              color: Colors.amberAccent,
-                              fontStyle: FontStyle.italic,
-                            ),
+                          color: Colors.amberAccent,
+                          fontStyle: FontStyle.italic,
+                        ),
                         textAlign: TextAlign.center,
                       ),
                     ),
@@ -247,9 +272,9 @@ class _DashboardState extends State<Dashboard> {
                 child: Text(
                   formatBalance(balanceMsats, showMsats),
                   style: Theme.of(context).textTheme.displayLarge?.copyWith(
-                        color: Theme.of(context).colorScheme.primary,
-                        fontWeight: FontWeight.bold,
-                      ),
+                    color: Theme.of(context).colorScheme.primary,
+                    fontWeight: FontWeight.bold,
+                  ),
                   textAlign: TextAlign.center,
                 ),
               ),
@@ -258,76 +283,93 @@ class _DashboardState extends State<Dashboard> {
               alignment: Alignment.centerLeft,
               child: Text(
                 "Recent Transactions",
-                style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                      fontWeight: FontWeight.bold,
-                    ),
+                style: Theme.of(
+                  context,
+                ).textTheme.titleMedium?.copyWith(fontWeight: FontWeight.bold),
               ),
             ),
             const SizedBox(height: 16),
             isLoadingTransactions
                 ? const CircularProgressIndicator()
                 : _transactions.isEmpty
-                    ? Text(_getNoTransactionsMessage())
-                    : SizedBox(
-                        height: 300,
-                        child: ListView.builder(
-                          controller: _scrollController,
-                          itemCount: _transactions.length + (_hasMore ? 1 : 0),
-                          itemBuilder: (context, index) {
-                            if (index == _transactions.length) {
-                              return const Padding(
-                                padding: EdgeInsets.all(8.0),
-                                child: Center(child: CircularProgressIndicator()),
-                              );
-                            }
+                ? Text(_getNoTransactionsMessage())
+                : SizedBox(
+                  height: 300,
+                  child: ListView.builder(
+                    controller: _scrollController,
+                    itemCount: _transactions.length + (_hasMore ? 1 : 0),
+                    itemBuilder: (context, index) {
+                      if (index == _transactions.length) {
+                        return const Padding(
+                          padding: EdgeInsets.all(8.0),
+                          child: Center(child: CircularProgressIndicator()),
+                        );
+                      }
 
-                            final tx = _transactions[index];
-                            final isIncoming = tx.received;
-                            final date = DateTime.fromMillisecondsSinceEpoch(tx.timestamp.toInt());
-                            final formattedDate = DateFormat.yMMMd().add_jm().format(date);
-                            final formattedAmount = formatBalance(tx.amount, false);
+                      final tx = _transactions[index];
+                      final isIncoming = tx.received;
+                      final date = DateTime.fromMillisecondsSinceEpoch(
+                        tx.timestamp.toInt(),
+                      );
+                      final formattedDate = DateFormat.yMMMd().add_jm().format(
+                        date,
+                      );
+                      final formattedAmount = formatBalance(tx.amount, false);
 
-                            IconData moduleIcon;
-                            switch (tx.module) {
-                              case 'ln':
-                              case 'lnv2':
-                                moduleIcon = Icons.flash_on;
-                                break;
-                              case 'wallet':
-                                moduleIcon = Icons.link;
-                                break;
-                              case 'mint':
-                                moduleIcon = Icons.currency_bitcoin;
-                                break;
-                              default:
-                                moduleIcon = Icons.help_outline;
-                            }
+                      IconData moduleIcon;
+                      switch (tx.module) {
+                        case 'ln':
+                        case 'lnv2':
+                          moduleIcon = Icons.flash_on;
+                          break;
+                        case 'wallet':
+                          moduleIcon = Icons.link;
+                          break;
+                        case 'mint':
+                          moduleIcon = Icons.currency_bitcoin;
+                          break;
+                        default:
+                          moduleIcon = Icons.help_outline;
+                      }
 
-                            final amountStyle = TextStyle(
-                              fontWeight: FontWeight.bold,
-                              color: isIncoming ? Colors.greenAccent : Colors.redAccent,
-                            );
+                      final amountStyle = TextStyle(
+                        fontWeight: FontWeight.bold,
+                        color:
+                            isIncoming ? Colors.greenAccent : Colors.redAccent,
+                      );
 
-                            return Card(
-                              elevation: 4,
-                              margin: const EdgeInsets.symmetric(vertical: 6),
-                              color: Theme.of(context).colorScheme.surface,
-                              child: ListTile(
-                                leading: CircleAvatar(
-                                  backgroundColor: isIncoming ? Colors.greenAccent.withOpacity(0.1) : Colors.redAccent.withOpacity(0.1),
-                                  child: Icon(
-                                    moduleIcon,
-                                    color: isIncoming ? Colors.greenAccent : Colors.redAccent,
-                                  ),
-                                ),
-                                title: Text(isIncoming ? "Received" : "Sent", style: Theme.of(context).textTheme.bodyMedium),
-                                subtitle: Text(formattedDate, style: Theme.of(context).textTheme.bodyMedium),
-                                trailing: Text(formattedAmount, style: amountStyle),
-                              ),
-                            );
-                          },
+                      return Card(
+                        elevation: 4,
+                        margin: const EdgeInsets.symmetric(vertical: 6),
+                        color: Theme.of(context).colorScheme.surface,
+                        child: ListTile(
+                          leading: CircleAvatar(
+                            backgroundColor:
+                                isIncoming
+                                    ? Colors.greenAccent.withOpacity(0.1)
+                                    : Colors.redAccent.withOpacity(0.1),
+                            child: Icon(
+                              moduleIcon,
+                              color:
+                                  isIncoming
+                                      ? Colors.greenAccent
+                                      : Colors.redAccent,
+                            ),
+                          ),
+                          title: Text(
+                            isIncoming ? "Received" : "Sent",
+                            style: Theme.of(context).textTheme.bodyMedium,
+                          ),
+                          subtitle: Text(
+                            formattedDate,
+                            style: Theme.of(context).textTheme.bodyMedium,
+                          ),
+                          trailing: Text(formattedAmount, style: amountStyle),
                         ),
-                      ),
+                      );
+                    },
+                  ),
+                ),
           ],
         ),
       ),
@@ -346,10 +388,7 @@ class _DashboardState extends State<Dashboard> {
             icon: Icon(Icons.flash_on),
             label: 'Lightning',
           ),
-          BottomNavigationBarItem(
-            icon: Icon(Icons.link),
-            label: 'Onchain',
-          ),
+          BottomNavigationBarItem(icon: Icon(Icons.link), label: 'Onchain'),
           BottomNavigationBarItem(
             icon: Icon(Icons.currency_bitcoin),
             label: 'Ecash',

--- a/lib/discover.dart
+++ b/lib/discover.dart
@@ -26,7 +26,10 @@ class _Discover extends State<Discover> {
     final theme = Theme.of(context);
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Discover Federations', style: TextStyle(fontWeight: FontWeight.bold)),
+        title: const Text(
+          'Discover Federations',
+          style: TextStyle(fontWeight: FontWeight.bold),
+        ),
         centerTitle: true,
         elevation: 0,
       ),
@@ -36,9 +39,16 @@ class _Discover extends State<Discover> {
           if (snapshot.connectionState == ConnectionState.waiting) {
             return const Center(child: CircularProgressIndicator());
           } else if (snapshot.hasError) {
-            return Center(child: Text("Error: ${snapshot.error}", style: TextStyle(color: theme.colorScheme.error)));
+            return Center(
+              child: Text(
+                "Error: ${snapshot.error}",
+                style: TextStyle(color: theme.colorScheme.error),
+              ),
+            );
           } else if (!snapshot.hasData || snapshot.data!.isEmpty) {
-            return const Center(child: Text("No public federations available to join"));
+            return const Center(
+              child: Text("No public federations available to join"),
+            );
           }
 
           final federations = snapshot.data!;
@@ -50,7 +60,9 @@ class _Discover extends State<Discover> {
               final federation = federations[index];
               return Card(
                 elevation: 2,
-                shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(16),
+                ),
                 child: Padding(
                   padding: const EdgeInsets.all(16),
                   child: Row(
@@ -58,16 +70,26 @@ class _Discover extends State<Discover> {
                     children: [
                       ClipRRect(
                         borderRadius: BorderRadius.circular(12),
-                        child: federation.picture != null && federation.picture!.isNotEmpty
-                            ? Image.network(
-                                federation.picture!,
-                                width: 50,
-                                height: 50,
-                                fit: BoxFit.cover,
-                                errorBuilder: (_, __, ___) =>
-                                    Image.asset('assets/images/fedimint.png', width: 50, height: 50),
-                              )
-                            : Image.asset('assets/images/fedimint.png', width: 50, height: 50),
+                        child:
+                            federation.picture != null &&
+                                    federation.picture!.isNotEmpty
+                                ? Image.network(
+                                  federation.picture!,
+                                  width: 50,
+                                  height: 50,
+                                  fit: BoxFit.cover,
+                                  errorBuilder:
+                                      (_, __, ___) => Image.asset(
+                                        'assets/images/fedimint.png',
+                                        width: 50,
+                                        height: 50,
+                                      ),
+                                )
+                                : Image.asset(
+                                  'assets/images/fedimint.png',
+                                  width: 50,
+                                  height: 50,
+                                ),
                       ),
                       const SizedBox(width: 16),
                       Expanded(
@@ -76,7 +98,9 @@ class _Discover extends State<Discover> {
                           children: [
                             Text(
                               federation.federationName,
-                              style: theme.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w600),
+                              style: theme.textTheme.titleMedium?.copyWith(
+                                fontWeight: FontWeight.w600,
+                              ),
                             ),
                             const SizedBox(height: 4),
                             Text(
@@ -85,7 +109,8 @@ class _Discover extends State<Discover> {
                                 color: theme.colorScheme.onSurfaceVariant,
                               ),
                             ),
-                            if (federation.about != null && federation.about!.isNotEmpty) ...[
+                            if (federation.about != null &&
+                                federation.about!.isNotEmpty) ...[
                               const SizedBox(height: 6),
                               Text(
                                 federation.about!,
@@ -100,41 +125,54 @@ class _Discover extends State<Discover> {
                       const SizedBox(width: 12),
                       ElevatedButton(
                         style: ElevatedButton.styleFrom(
-                          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+                          shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(12),
+                          ),
                           minimumSize: const Size(70, 36),
                           padding: const EdgeInsets.symmetric(horizontal: 12),
                         ),
                         onPressed: () async {
                           setState(() => _gettingMetadata = federation);
-                          final meta = await getFederationMeta(inviteCode: federation.inviteCodes.first);
+                          final meta = await getFederationMeta(
+                            inviteCode: federation.inviteCodes.first,
+                          );
                           setState(() => _gettingMetadata = null);
                           final fed = await showCarbineModalBottomSheet(
                             context: context,
                             child: FederationPreview(
-                                federationName: meta.$2.federationName,
-                                inviteCode: meta.$2.inviteCode,
-                                welcomeMessage: meta.$1.welcome,
-                                imageUrl: meta.$1.picture,
-                                joinable: true,
-                                guardians: meta.$1.guardians,
-                                network: meta.$2.network,
-                              ),
+                              federationName: meta.$2.federationName,
+                              inviteCode: meta.$2.inviteCode,
+                              welcomeMessage: meta.$1.welcome,
+                              imageUrl: meta.$1.picture,
+                              joinable: true,
+                              guardians: meta.$1.guardians,
+                              network: meta.$2.network,
+                            ),
                           );
 
-                          await Future.delayed(const Duration(milliseconds: 400));
+                          await Future.delayed(
+                            const Duration(milliseconds: 400),
+                          );
                           widget.onJoin(fed);
                           if (context.mounted) Navigator.pop(context);
                           ScaffoldMessenger.of(context).showSnackBar(
-                            SnackBar(content: Text("Joined ${fed.federationName}")),
+                            SnackBar(
+                              content: Text("Joined ${fed.federationName}"),
+                            ),
                           );
                         },
-                        child: (_gettingMetadata != null && _gettingMetadata == federation)
-                            ? const SizedBox(
-                                width: 16,
-                                height: 16,
-                                child: CircularProgressIndicator(strokeWidth: 2, color: Colors.white),
-                              )
-                            : const Text("Join"),
+                        child:
+                            (_gettingMetadata != null &&
+                                    _gettingMetadata == federation)
+                                ? const SizedBox(
+                                  width: 16,
+                                  height: 16,
+                                  child: CircularProgressIndicator(
+                                    strokeWidth: 2,
+                                    color: Colors.white,
+                                  ),
+                                )
+                                : const Text("Join"),
                       ),
                     ],
                   ),

--- a/lib/ecash_send.dart
+++ b/lib/ecash_send.dart
@@ -8,11 +8,7 @@ class EcashSend extends StatefulWidget {
   final FederationSelector fed;
   final BigInt amountSats;
 
-  const EcashSend({
-    super.key,
-    required this.fed,
-    required this.amountSats,
-  });
+  const EcashSend({super.key, required this.fed, required this.amountSats});
 
   @override
   State<EcashSend> createState() => _EcashSendState();
@@ -68,10 +64,13 @@ class _EcashSendState extends State<EcashSend> {
         operationId: opId,
       );
       if (mounted) {
-        Navigator.of(context, rootNavigator: true).popUntil((route) => route.isFirst);
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('✅ Ecash reclaimed')),
-        );
+        Navigator.of(
+          context,
+          rootNavigator: true,
+        ).popUntil((route) => route.isFirst);
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(const SnackBar(content: Text('✅ Ecash reclaimed')));
       }
     }
 
@@ -102,7 +101,10 @@ class _EcashSendState extends State<EcashSend> {
 
   void _copyEcash() {
     Clipboard.setData(ClipboardData(text: _ecash!));
-    Navigator.of(context, rootNavigator: true).popUntil((route) => route.isFirst);
+    Navigator.of(
+      context,
+      rootNavigator: true,
+    ).popUntil((route) => route.isFirst);
     ScaffoldMessenger.of(context).showSnackBar(
       const SnackBar(content: Text('✅ Ecash copied to clipboard')),
     );
@@ -154,7 +156,9 @@ class _EcashSendState extends State<EcashSend> {
             // QR Code
             Card(
               margin: EdgeInsets.zero,
-              shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(16),
+              ),
               child: Padding(
                 padding: const EdgeInsets.all(16),
                 child: QrImageView(
@@ -213,23 +217,21 @@ class _EcashSendState extends State<EcashSend> {
             _reclaiming
                 ? const CircularProgressIndicator()
                 : SizedBox(
-                    width: double.infinity,
-                    child: ElevatedButton.icon(
-                      onPressed: _reclaimEcash,
-                      icon: const Icon(Icons.undo),
-                      label: const Text("Reclaim"),
-                      style: ElevatedButton.styleFrom(
-                        backgroundColor: Colors.red,
-                        foregroundColor: Colors.white,
-                        padding: const EdgeInsets.symmetric(vertical: 16),
-                      ),
+                  width: double.infinity,
+                  child: ElevatedButton.icon(
+                    onPressed: _reclaimEcash,
+                    icon: const Icon(Icons.undo),
+                    label: const Text("Reclaim"),
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: Colors.red,
+                      foregroundColor: Colors.white,
+                      padding: const EdgeInsets.symmetric(vertical: 16),
                     ),
                   ),
+                ),
           ],
         ),
       ),
     );
   }
 }
-
-

--- a/lib/fed_preview.dart
+++ b/lib/fed_preview.dart
@@ -28,7 +28,7 @@ class FederationPreview extends StatefulWidget {
 }
 
 class _FederationPreviewState extends State<FederationPreview> {
-  bool isJoining = false; 
+  bool isJoining = false;
 
   Future<void> _onButtonPressed() async {
     if (widget.joinable) {
@@ -57,10 +57,16 @@ class _FederationPreviewState extends State<FederationPreview> {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final totalGuardians = widget.guardians != null ? widget.guardians!.length : 0;
+    final totalGuardians =
+        widget.guardians != null ? widget.guardians!.length : 0;
     final thresh = threshold(totalGuardians);
-    final onlineGuardians = widget.guardians != null ? widget.guardians!.where((g) => g.version != null).toList() : [];
-    final isFederationOnline = totalGuardians > 0 && onlineGuardians.length >= threshold(totalGuardians);
+    final onlineGuardians =
+        widget.guardians != null
+            ? widget.guardians!.where((g) => g.version != null).toList()
+            : [];
+    final isFederationOnline =
+        totalGuardians > 0 &&
+        onlineGuardians.length >= threshold(totalGuardians);
 
     return Padding(
       padding: const EdgeInsets.all(16),
@@ -68,7 +74,6 @@ class _FederationPreviewState extends State<FederationPreview> {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
-
             if (widget.network.toLowerCase() != 'bitcoin') ...[
               Container(
                 margin: const EdgeInsets.only(bottom: 16),
@@ -99,21 +104,22 @@ class _FederationPreviewState extends State<FederationPreview> {
                 child: SizedBox(
                   width: 150,
                   height: 150,
-                  child: widget.imageUrl != null
-                      ? Image.network(
-                          widget.imageUrl!,
-                          fit: BoxFit.cover,
-                          errorBuilder: (context, error, stackTrace) {
-                            return Image.asset(
-                              'assets/images/fedimint.png',
-                              fit: BoxFit.cover,
-                            );
-                          },
-                        )
-                      : Image.asset(
-                          'assets/images/fedimint.png',
-                          fit: BoxFit.cover,
-                        ),
+                  child:
+                      widget.imageUrl != null
+                          ? Image.network(
+                            widget.imageUrl!,
+                            fit: BoxFit.cover,
+                            errorBuilder: (context, error, stackTrace) {
+                              return Image.asset(
+                                'assets/images/fedimint.png',
+                                fit: BoxFit.cover,
+                              );
+                            },
+                          )
+                          : Image.asset(
+                            'assets/images/fedimint.png',
+                            fit: BoxFit.cover,
+                          ),
                 ),
               ),
             ),
@@ -123,7 +129,9 @@ class _FederationPreviewState extends State<FederationPreview> {
             // Federation name
             Text(
               widget.federationName,
-              style: theme.textTheme.headlineSmall?.copyWith(fontWeight: FontWeight.bold),
+              style: theme.textTheme.headlineSmall?.copyWith(
+                fontWeight: FontWeight.bold,
+              ),
               textAlign: TextAlign.center,
             ),
 
@@ -157,16 +165,21 @@ class _FederationPreviewState extends State<FederationPreview> {
                       fontWeight: FontWeight.bold,
                     ),
                   ),
-                  child: isJoining
-                      ? const SizedBox(
-                          height: 20,
-                          width: 20,
-                          child: CircularProgressIndicator(
-                            color: Colors.black,
-                            strokeWidth: 2,
+                  child:
+                      isJoining
+                          ? const SizedBox(
+                            height: 20,
+                            width: 20,
+                            child: CircularProgressIndicator(
+                              color: Colors.black,
+                              strokeWidth: 2,
+                            ),
+                          )
+                          : Text(
+                            widget.joinable
+                                ? "Join Federation"
+                                : "Copy Invite Code",
                           ),
-                        )
-                      : Text(widget.joinable ? "Join Federation" : "Copy Invite Code"),
                 ),
               ),
 
@@ -175,7 +188,9 @@ class _FederationPreviewState extends State<FederationPreview> {
                 const SizedBox(height: 24),
                 Text(
                   'Guardians ($thresh/$totalGuardians federation)',
-                  style: theme.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.bold),
+                  style: theme.textTheme.titleMedium?.copyWith(
+                    fontWeight: FontWeight.bold,
+                  ),
                 ),
                 const SizedBox(height: 8),
                 ListView.builder(
@@ -195,9 +210,10 @@ class _FederationPreviewState extends State<FederationPreview> {
                         size: 12,
                       ),
                       title: Text(guardian.name),
-                      subtitle: isOnline
-                          ? Text('Version: ${guardian.version}')
-                          : const Text('Offline'),
+                      subtitle:
+                          isOnline
+                              ? Text('Version: ${guardian.version}')
+                              : const Text('Offline'),
                     );
                   },
                 ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -76,7 +76,7 @@ class _MyAppState extends State<MyApp> {
 
   void _onJoinPressed(FederationSelector fed) {
     _setSelectedFederation(fed);
-    _refreshFederations(); 
+    _refreshFederations();
   }
 
   void _setSelectedFederation(FederationSelector fed) {
@@ -148,42 +148,43 @@ class _MyAppState extends State<MyApp> {
       debugShowCheckedModeBanner: false,
       theme: cypherpunkNinjaTheme,
       home: Builder(
-        builder: (innerContext) => Scaffold(
-          appBar: AppBar(
-            actions: _initialLoadComplete
-                ? [
-                    IconButton(
-                      icon: const Icon(Icons.qr_code_scanner),
-                      tooltip: 'Scan',
-                      onPressed: () => _onScanPressed(innerContext),
-                    ),
-                    IconButton(
-                      icon: const Icon(Icons.settings),
-                      tooltip: 'Settings',
-                      onPressed: () {
-                        setState(() {
-                          _currentIndex = 1;
-                          _selectedFederation = null;
-                        });
-                      },
-                    ),
-                  ]
-                : null,
-          ),
-          drawer: _initialLoadComplete
-              ? SafeArea(
-                  child: FederationSidebar(
-                    key: ValueKey(_refreshTrigger),
-                    federationsFuture: _federationFuture,
-                    onFederationSelected: _setSelectedFederation,
-                  ),
-                )
-              : null,
-          body: SafeArea(child: bodyContent),
-        ),
+        builder:
+            (innerContext) => Scaffold(
+              appBar: AppBar(
+                actions:
+                    _initialLoadComplete
+                        ? [
+                          IconButton(
+                            icon: const Icon(Icons.qr_code_scanner),
+                            tooltip: 'Scan',
+                            onPressed: () => _onScanPressed(innerContext),
+                          ),
+                          IconButton(
+                            icon: const Icon(Icons.settings),
+                            tooltip: 'Settings',
+                            onPressed: () {
+                              setState(() {
+                                _currentIndex = 1;
+                                _selectedFederation = null;
+                              });
+                            },
+                          ),
+                        ]
+                        : null,
+              ),
+              drawer:
+                  _initialLoadComplete
+                      ? SafeArea(
+                        child: FederationSidebar(
+                          key: ValueKey(_refreshTrigger),
+                          federationsFuture: _federationFuture,
+                          onFederationSelected: _setSelectedFederation,
+                        ),
+                      )
+                      : null,
+              body: SafeArea(child: bodyContent),
+            ),
       ),
     );
   }
 }
-
-

--- a/lib/pay_preview.dart
+++ b/lib/pay_preview.dart
@@ -18,7 +18,8 @@ class PaymentPreviewWidget extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final amount = paymentPreview.amountMsats;
-    final feeFromPpm = (amount * paymentPreview.sendFeePpm) ~/ BigInt.from(1_000_000);
+    final feeFromPpm =
+        (amount * paymentPreview.sendFeePpm) ~/ BigInt.from(1_000_000);
     final fedFee = paymentPreview.fedFee;
     final fees = paymentPreview.sendFeeBase + feeFromPpm + fedFee;
     final total = amount + fees;
@@ -40,7 +41,9 @@ class PaymentPreviewWidget extends StatelessWidget {
           decoration: BoxDecoration(
             color: theme.colorScheme.surfaceContainer,
             borderRadius: BorderRadius.circular(12),
-            border: Border.all(color: theme.colorScheme.primary.withOpacity(0.25)),
+            border: Border.all(
+              color: theme.colorScheme.primary.withOpacity(0.25),
+            ),
           ),
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
@@ -71,7 +74,17 @@ class PaymentPreviewWidget extends StatelessWidget {
               ),
             ),
             onPressed: () {
-              Navigator.push(context, MaterialPageRoute(builder: (context) => SendPayment(fed: fed, invoice: paymentPreview.invoice, amountMsats: amount)));
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder:
+                      (context) => SendPayment(
+                        fed: fed,
+                        invoice: paymentPreview.invoice,
+                        amountMsats: amount,
+                      ),
+                ),
+              );
             },
           ),
         ),

--- a/lib/payment_selector.dart
+++ b/lib/payment_selector.dart
@@ -97,16 +97,19 @@ class _PaymentMethodSelectorState extends State<PaymentMethodSelector> {
 
         // Confirm Button
         ElevatedButton.icon(
-          onPressed: (_selected == 'invoice' || _isLightningFormValid)
-              ? _onConfirmPressed
-              : null,
+          onPressed:
+              (_selected == 'invoice' || _isLightningFormValid)
+                  ? _onConfirmPressed
+                  : null,
           icon: const Icon(Icons.check_circle),
           label: const Text('Confirm'),
           style: ElevatedButton.styleFrom(
             backgroundColor: theme.colorScheme.primary,
             foregroundColor: theme.colorScheme.onPrimary,
             padding: const EdgeInsets.symmetric(vertical: 16),
-            textStyle: theme.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w600),
+            textStyle: theme.textTheme.titleMedium?.copyWith(
+              fontWeight: FontWeight.w600,
+            ),
             shape: RoundedRectangleBorder(
               borderRadius: BorderRadius.circular(16),
             ),
@@ -122,25 +125,44 @@ class _PaymentMethodSelectorState extends State<PaymentMethodSelector> {
         final address = _lightningAddressController.text;
         final amount = BigInt.parse(_amountController.text) * BigInt.from(1000);
         print('Lightning Address: $address, Amount: $amount');
-        await Navigator.push(context, MaterialPageRoute(builder: (context) => SendPayment(fed: widget.fed, amountMsats: amount, lnAddress: address)));
+        await Navigator.push(
+          context,
+          MaterialPageRoute(
+            builder:
+                (context) => SendPayment(
+                  fed: widget.fed,
+                  amountMsats: amount,
+                  lnAddress: address,
+                ),
+          ),
+        );
       } catch (_) {
         print("Error paying lightning address");
       }
-      
     } else {
-      await Navigator.push(context, MaterialPageRoute(builder: (context) => ScanQRPage(selectedFed: widget.fed)));
+      await Navigator.push(
+        context,
+        MaterialPageRoute(
+          builder: (context) => ScanQRPage(selectedFed: widget.fed),
+        ),
+      );
     }
   }
 
-  Widget _buildOption({required String label, required IconData icon, required String value}) {
+  Widget _buildOption({
+    required String label,
+    required IconData icon,
+    required String value,
+  }) {
     final theme = Theme.of(context);
     final isSelected = _selected == value;
 
     return Expanded(
       child: GestureDetector(
-        onTap: () => setState(() {
-          _selected = value;
-        }),
+        onTap:
+            () => setState(() {
+              _selected = value;
+            }),
         child: AnimatedContainer(
           duration: const Duration(milliseconds: 200),
           padding: const EdgeInsets.symmetric(vertical: 16),
@@ -158,7 +180,8 @@ class _PaymentMethodSelectorState extends State<PaymentMethodSelector> {
               Text(
                 label,
                 style: theme.textTheme.bodyMedium?.copyWith(
-                  color: isSelected ? Colors.white : theme.colorScheme.onSurface,
+                  color:
+                      isSelected ? Colors.white : theme.colorScheme.onSurface,
                 ),
               ),
             ],
@@ -220,4 +243,3 @@ class _PaymentMethodSelectorState extends State<PaymentMethodSelector> {
     );
   }
 }
-

--- a/lib/request.dart
+++ b/lib/request.dart
@@ -72,16 +72,25 @@ class _RequestState extends State<Request> with SingleTickerProviderStateMixin {
       federationId: widget.fed.federationId,
       operationId: widget.operationId,
     );
-    Navigator.push(context, MaterialPageRoute(builder: (context) => Success(
-      lightning: true,
-      received: true,
-      amountMsats: widget.requestedAmountMsats
-    )));
+    Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder:
+            (context) => Success(
+              lightning: true,
+              received: true,
+              amountMsats: widget.requestedAmountMsats,
+            ),
+      ),
+    );
     await Future.delayed(const Duration(seconds: 4));
     if (mounted) {
-      Navigator.of(context, rootNavigator: true).popUntil((route) => route.isFirst);
+      Navigator.of(
+        context,
+        rootNavigator: true,
+      ).popUntil((route) => route.isFirst);
     }
-  } 
+  }
 
   void _copyInvoice() {
     Clipboard.setData(ClipboardData(text: widget.invoice));
@@ -109,8 +118,6 @@ class _RequestState extends State<Request> with SingleTickerProviderStateMixin {
     }
   }
 
-
-
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
@@ -126,11 +133,16 @@ class _RequestState extends State<Request> with SingleTickerProviderStateMixin {
             children: [
               const Spacer(),
               Container(
-                padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 12,
+                  vertical: 6,
+                ),
                 decoration: BoxDecoration(
                   color: theme.colorScheme.surfaceContainerHighest,
                   borderRadius: BorderRadius.circular(8),
-                  border: Border.all(color: theme.colorScheme.primary.withOpacity(0.5)),
+                  border: Border.all(
+                    color: theme.colorScheme.primary.withOpacity(0.5),
+                  ),
                 ),
                 child: Text(
                   _formatDuration(_remaining),
@@ -184,7 +196,9 @@ class _RequestState extends State<Request> with SingleTickerProviderStateMixin {
             decoration: BoxDecoration(
               color: theme.colorScheme.surfaceContainerHighest,
               borderRadius: BorderRadius.circular(12),
-              border: Border.all(color: theme.colorScheme.primary.withOpacity(0.4)),
+              border: Border.all(
+                color: theme.colorScheme.primary.withOpacity(0.4),
+              ),
             ),
             child: Row(
               children: [
@@ -201,11 +215,21 @@ class _RequestState extends State<Request> with SingleTickerProviderStateMixin {
                 IconButton(
                   icon: AnimatedSwitcher(
                     duration: const Duration(milliseconds: 300),
-                    transitionBuilder: (child, anim) =>
-                        ScaleTransition(scale: anim, child: child),
-                    child: _copied
-                        ? Icon(Icons.check, key: const ValueKey('copied'), color: theme.colorScheme.primary)
-                        : Icon(Icons.copy, key: const ValueKey('copy'), color: theme.colorScheme.primary),
+                    transitionBuilder:
+                        (child, anim) =>
+                            ScaleTransition(scale: anim, child: child),
+                    child:
+                        _copied
+                            ? Icon(
+                              Icons.check,
+                              key: const ValueKey('copied'),
+                              color: theme.colorScheme.primary,
+                            )
+                            : Icon(
+                              Icons.copy,
+                              key: const ValueKey('copy'),
+                              color: theme.colorScheme.primary,
+                            ),
                   ),
                   onPressed: _copyInvoice,
                 ),
@@ -219,12 +243,18 @@ class _RequestState extends State<Request> with SingleTickerProviderStateMixin {
             decoration: BoxDecoration(
               color: theme.colorScheme.surfaceContainer,
               borderRadius: BorderRadius.circular(12),
-              border: Border.all(color: theme.colorScheme.primary.withOpacity(0.25)),
+              border: Border.all(
+                color: theme.colorScheme.primary.withOpacity(0.25),
+              ),
             ),
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                buildDetailRow(theme, 'Amount', formatBalance(widget.requestedAmountMsats, true)),
+                buildDetailRow(
+                  theme,
+                  'Amount',
+                  formatBalance(widget.requestedAmountMsats, true),
+                ),
                 buildDetailRow(theme, 'Fees', formatBalance(fees, true)),
                 buildDetailRow(theme, 'Gateway', widget.gateway),
                 buildDetailRow(theme, 'Payee Pubkey', widget.pubkey),
@@ -237,4 +267,3 @@ class _RequestState extends State<Request> with SingleTickerProviderStateMixin {
     );
   }
 }
-

--- a/lib/scan.dart
+++ b/lib/scan.dart
@@ -19,7 +19,9 @@ class _ScanQRPageState extends State<ScanQRPage> {
   bool _isPasting = false;
 
   Future<void> _processText(String text) async {
-    if (text.startsWith("fed") && !text.startsWith("fedimint") && widget.selectedFed == null) {
+    if (text.startsWith("fed") &&
+        !text.startsWith("fedimint") &&
+        widget.selectedFed == null) {
       final meta = await getFederationMeta(inviteCode: text);
 
       final fed = await showCarbineModalBottomSheet(
@@ -39,20 +41,30 @@ class _ScanQRPageState extends State<ScanQRPage> {
         await Future.delayed(const Duration(milliseconds: 400));
         Navigator.pop(context, fed);
       }
-
     } else if (text.startsWith("ln")) {
       if (widget.selectedFed != null) {
-        final preview = await paymentPreview(federationId: widget.selectedFed!.federationId, bolt11: text);
+        final preview = await paymentPreview(
+          federationId: widget.selectedFed!.federationId,
+          bolt11: text,
+        );
         if (widget.selectedFed!.network != preview.network) {
           ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(content: Text("Cannot pay invoice from different network.")),
+            const SnackBar(
+              content: Text("Cannot pay invoice from different network."),
+            ),
           );
           return;
         }
-        final bal = await balance(federationId: widget.selectedFed!.federationId);
+        final bal = await balance(
+          federationId: widget.selectedFed!.federationId,
+        );
         if (bal < preview.amountMsats) {
           ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(content: Text("This federation does not have enough funds to pay this invoice")),
+            const SnackBar(
+              content: Text(
+                "This federation does not have enough funds to pay this invoice",
+              ),
+            ),
           );
           return;
         }
@@ -89,9 +101,9 @@ class _ScanQRPageState extends State<ScanQRPage> {
     final text = clipboardData?.text ?? '';
 
     if (text.isEmpty) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text("Clipboard is empty")),
-      );
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(const SnackBar(content: Text("Clipboard is empty")));
 
       setState(() {
         _isPasting = false;
@@ -112,15 +124,18 @@ class _ScanQRPageState extends State<ScanQRPage> {
     return SafeArea(
       child: Scaffold(
         appBar: AppBar(
-            title: const Text('Scan QR', style: TextStyle(fontWeight: FontWeight.bold)),
-            centerTitle: true,
-            backgroundColor: Colors.transparent,
-            elevation: 0,
-            leading: IconButton(
-              icon: const Icon(Icons.close),
-              onPressed: () => Navigator.of(context).pop(),
-            ),
+          title: const Text(
+            'Scan QR',
+            style: TextStyle(fontWeight: FontWeight.bold),
           ),
+          centerTitle: true,
+          backgroundColor: Colors.transparent,
+          elevation: 0,
+          leading: IconButton(
+            icon: const Icon(Icons.close),
+            onPressed: () => Navigator.of(context).pop(),
+          ),
+        ),
         body: Stack(
           children: [
             Positioned.fill(
@@ -139,23 +154,26 @@ class _ScanQRPageState extends State<ScanQRPage> {
                 padding: const EdgeInsets.all(24.0),
                 child: ElevatedButton.icon(
                   onPressed: _isPasting ? null : _pasteFromClipboard,
-                  icon: _isPasting
-                      ? const SizedBox(
-                          width: 20,
-                          height: 20,
-                          child: CircularProgressIndicator(
-                            color: Colors.white,
-                            strokeWidth: 2.0,
-                          ),
-                        )
-                      : const Icon(Icons.paste),
-                  label: Text(_isPasting ? "Pasting..." : "Paste from Clipboard"),
+                  icon:
+                      _isPasting
+                          ? const SizedBox(
+                            width: 20,
+                            height: 20,
+                            child: CircularProgressIndicator(
+                              color: Colors.white,
+                              strokeWidth: 2.0,
+                            ),
+                          )
+                          : const Icon(Icons.paste),
+                  label: Text(
+                    _isPasting ? "Pasting..." : "Paste from Clipboard",
+                  ),
                 ),
               ),
             ),
           ],
         ),
-      )
+      ),
     );
   }
 }

--- a/lib/send.dart
+++ b/lib/send.dart
@@ -37,7 +37,11 @@ class _SendPaymentState extends State<SendPayment> {
       );
       return operationId;
     } else {
-      final operationId = await sendLnaddress(federationId: widget.fed.federationId, amountMsats: widget.amountMsats, address: widget.lnAddress!);
+      final operationId = await sendLnaddress(
+        federationId: widget.fed.federationId,
+        amountMsats: widget.amountMsats,
+        address: widget.lnAddress!,
+      );
       return operationId;
     }
   }
@@ -62,25 +66,29 @@ class _SendPaymentState extends State<SendPayment> {
       Navigator.push(
         context,
         MaterialPageRoute(
-          builder: (context) => Success(
-            lightning: true,
-            received: false,
-            amountMsats: widget.amountMsats,
-          ),
+          builder:
+              (context) => Success(
+                lightning: true,
+                received: false,
+                amountMsats: widget.amountMsats,
+              ),
         ),
       );
 
       await Future.delayed(const Duration(seconds: 4));
 
       if (mounted) {
-        Navigator.of(context, rootNavigator: true).popUntil((route) => route.isFirst);
+        Navigator.of(
+          context,
+          rootNavigator: true,
+        ).popUntil((route) => route.isFirst);
       }
     } catch (e) {
       debugPrint('Error while sending payment: $e');
       if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Failed to send payment')),
-      );
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(const SnackBar(content: Text('Failed to send payment')));
       Navigator.of(context).pop(); // Close modal on failure
     }
   }
@@ -92,27 +100,30 @@ class _SendPaymentState extends State<SendPayment> {
     return Center(
       child: AnimatedSwitcher(
         duration: const Duration(milliseconds: 500),
-        child: _isSending
-            ? Column(
-                key: const ValueKey('sending'),
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  const SizedBox(height: 24),
-                  CircularProgressIndicator(
-                    valueColor: AlwaysStoppedAnimation(theme.colorScheme.primary),
-                    strokeWidth: 3,
-                  ),
-                  const SizedBox(height: 24),
-                  Text(
-                    'Sending Payment',
-                    style: theme.textTheme.titleLarge?.copyWith(
-                      fontWeight: FontWeight.bold,
-                      color: theme.colorScheme.onSurface,
+        child:
+            _isSending
+                ? Column(
+                  key: const ValueKey('sending'),
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    const SizedBox(height: 24),
+                    CircularProgressIndicator(
+                      valueColor: AlwaysStoppedAnimation(
+                        theme.colorScheme.primary,
+                      ),
+                      strokeWidth: 3,
                     ),
-                  ),
-                ],
-              )
-            : const SizedBox.shrink(), // Replaced by Success screen
+                    const SizedBox(height: 24),
+                    Text(
+                      'Sending Payment',
+                      style: theme.textTheme.titleLarge?.copyWith(
+                        fontWeight: FontWeight.bold,
+                        color: theme.colorScheme.onSurface,
+                      ),
+                    ),
+                  ],
+                )
+                : const SizedBox.shrink(), // Replaced by Success screen
       ),
     );
   }

--- a/lib/setttings.dart
+++ b/lib/setttings.dart
@@ -18,8 +18,13 @@ class SettingsScreen extends StatelessWidget {
             title: "Discover",
             subtitle: "Find new Federations using Nostr",
             onTap: () {
-              Navigator.push(context, MaterialPageRoute(builder: (context) => Discover(onJoin: onJoin)));
-            }
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (context) => Discover(onJoin: onJoin),
+                ),
+              );
+            },
           ),
           _SettingsOption(
             icon: Icons.link,

--- a/lib/sidebar.dart
+++ b/lib/sidebar.dart
@@ -21,10 +21,7 @@ class FederationSidebar extends StatelessWidget {
         decoration: BoxDecoration(
           color: Theme.of(context).colorScheme.surface,
           boxShadow: [
-            BoxShadow(
-              color: Colors.black.withOpacity(0.6),
-              blurRadius: 12,
-            ),
+            BoxShadow(color: Colors.black.withOpacity(0.6), blurRadius: 12),
           ],
         ),
         child: FutureBuilder<List<FederationSelector>>(
@@ -46,7 +43,9 @@ class FederationSidebar extends StatelessWidget {
                   height: 80,
                   padding: const EdgeInsets.all(16),
                   decoration: BoxDecoration(
-                    color: Colors.grey[900], // Slightly lighter for header contrast
+                    color:
+                        Colors
+                            .grey[900], // Slightly lighter for header contrast
                     border: Border(
                       bottom: BorderSide(color: Colors.grey.shade800),
                     ),
@@ -61,13 +60,15 @@ class FederationSidebar extends StatelessWidget {
                     ),
                   ),
                 ),
-                ...federations!.map((selector) => FederationListItem(
-                  fed: selector,
-                  onTap: () {
-                    Navigator.of(context).pop();
-                    onFederationSelected(selector);
-                  },
-                )),
+                ...federations!.map(
+                  (selector) => FederationListItem(
+                    fed: selector,
+                    onTap: () {
+                      Navigator.of(context).pop();
+                      onFederationSelected(selector);
+                    },
+                  ),
+                ),
               ],
             );
           },
@@ -101,14 +102,11 @@ class _FederationListItemState extends State<FederationListItem> {
   }
 
   Future<void> _initializeData() async {
-    await Future.wait([
-      _loadBalance(),
-      _loadFederationMeta(),
-    ]);
+    await Future.wait([_loadBalance(), _loadFederationMeta()]);
     setState(() {
       isLoading = false;
     });
-  } 
+  }
 
   Future<void> _loadFederationMeta() async {
     try {
@@ -141,15 +139,16 @@ class _FederationListItemState extends State<FederationListItem> {
       guardians!.every((g) => g.version != null);
 
   int get numOnlineGuardians =>
-    guardians != null ? guardians!.where((g) => g.version != null).length : 0;
+      guardians != null ? guardians!.where((g) => g.version != null).length : 0;
 
   @override
   Widget build(BuildContext context) {
     final numGuardians = guardians?.length ?? 0;
     final thresh = guardians != null ? threshold(numGuardians) : 0;
-    final onlineColor = numOnlineGuardians == numGuardians
-        ? Colors.greenAccent
-        : numOnlineGuardians >= thresh
+    final onlineColor =
+        numOnlineGuardians == numGuardians
+            ? Colors.greenAccent
+            : numOnlineGuardians >= thresh
             ? Colors.amberAccent
             : Colors.redAccent;
 
@@ -167,9 +166,11 @@ class _FederationListItemState extends State<FederationListItem> {
               children: [
                 CircleAvatar(
                   radius: 24,
-                  backgroundImage: federationImageUrl != null
-                      ? NetworkImage(federationImageUrl!)
-                      : const AssetImage('assets/images/fedimint.png') as ImageProvider,
+                  backgroundImage:
+                      federationImageUrl != null
+                          ? NetworkImage(federationImageUrl!)
+                          : const AssetImage('assets/images/fedimint.png')
+                              as ImageProvider,
                   backgroundColor: Colors.black,
                   onBackgroundImageError: (_, __) {
                     setState(() {
@@ -185,9 +186,9 @@ class _FederationListItemState extends State<FederationListItem> {
                       Text(
                         widget.fed.federationName,
                         style: Theme.of(context).textTheme.bodyLarge!.copyWith(
-                              fontWeight: FontWeight.bold,
-                              color: Colors.greenAccent,
-                            ),
+                          fontWeight: FontWeight.bold,
+                          color: Colors.greenAccent,
+                        ),
                       ),
                       const SizedBox(height: 4),
                       Text(
@@ -199,27 +200,27 @@ class _FederationListItemState extends State<FederationListItem> {
                       const SizedBox(height: 4),
                       guardians == null
                           ? const SizedBox(
-                              width: 16,
-                              height: 16,
-                              child: CircularProgressIndicator(
-                                color: Colors.greenAccent,
-                                strokeWidth: 2,
-                              ),
-                            )
-                          : Row(
-                              children: [
-                                Text(
-                                  guardians!.isEmpty
-                                      ? 'Offline'
-                                      : numGuardians == 1
-                                          ? '1 guardian'
-                                          : '$numGuardians guardians',
-                                  style: Theme.of(context).textTheme.bodySmall,
-                                ),
-                                const SizedBox(width: 6),
-                                Icon(Icons.circle, size: 10, color: onlineColor),
-                              ],
+                            width: 16,
+                            height: 16,
+                            child: CircularProgressIndicator(
+                              color: Colors.greenAccent,
+                              strokeWidth: 2,
                             ),
+                          )
+                          : Row(
+                            children: [
+                              Text(
+                                guardians!.isEmpty
+                                    ? 'Offline'
+                                    : numGuardians == 1
+                                    ? '1 guardian'
+                                    : '$numGuardians guardians',
+                                style: Theme.of(context).textTheme.bodySmall,
+                              ),
+                              const SizedBox(width: 6),
+                              Icon(Icons.circle, size: 10, color: onlineColor),
+                            ],
+                          ),
                     ],
                   ),
                 ),

--- a/lib/success.dart
+++ b/lib/success.dart
@@ -38,14 +38,8 @@ class Success extends StatelessWidget {
           Center(
             child: Animate(
               effects: [
-                ScaleEffect(
-                  duration: 600.ms,
-                  curve: Curves.easeOutBack,
-                ),
-                FadeEffect(
-                  duration: 600.ms,
-                  curve: Curves.easeIn,
-                ),
+                ScaleEffect(duration: 600.ms, curve: Curves.easeOutBack),
+                FadeEffect(duration: 600.ms, curve: Curves.easeIn),
               ],
               child: Column(
                 mainAxisSize: MainAxisSize.min,
@@ -85,4 +79,3 @@ class Success extends StatelessWidget {
     );
   }
 }
-

--- a/lib/theme.dart
+++ b/lib/theme.dart
@@ -32,7 +32,10 @@ final ThemeData cypherpunkNinjaTheme = ThemeData(
   textTheme: const TextTheme(
     bodyLarge: TextStyle(color: Colors.white),
     bodyMedium: TextStyle(color: Colors.white70),
-    titleLarge: TextStyle(color: Colors.greenAccent, fontWeight: FontWeight.bold),
+    titleLarge: TextStyle(
+      color: Colors.greenAccent,
+      fontWeight: FontWeight.bold,
+    ),
   ),
   buttonTheme: const ButtonThemeData(
     buttonColor: Colors.greenAccent,
@@ -145,4 +148,3 @@ String getAbbreviatedInvoice(String invoice) {
   if (invoice.length <= 14) return invoice;
   return '${invoice.substring(0, 7)}...${invoice.substring(invoice.length - 7)}';
 }
-

--- a/lib/welcome.dart
+++ b/lib/welcome.dart
@@ -25,15 +25,13 @@ class _WelcomeWidgetState extends State<WelcomeWidget> {
 
   bool get isMobile {
     return defaultTargetPlatform == TargetPlatform.iOS ||
-        defaultTargetPlatform == TargetPlatform.android || kIsWeb;
+        defaultTargetPlatform == TargetPlatform.android ||
+        kIsWeb;
   }
 
   Widget _buildPage({required Widget content}) {
     return Center(
-      child: Padding(
-        padding: const EdgeInsets.all(24.0),
-        child: content,
-      ),
+      child: Padding(padding: const EdgeInsets.all(24.0), child: content),
     );
   }
 
@@ -43,33 +41,52 @@ class _WelcomeWidgetState extends State<WelcomeWidget> {
       children: [
         Icon(Icons.explore, size: 80, color: Theme.of(context).primaryColor),
         const SizedBox(height: 32),
-        const Text('Discover Federations', style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold)),
+        const Text(
+          'Discover Federations',
+          style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
+        ),
         const SizedBox(height: 16),
         RichText(
           textAlign: TextAlign.center,
           text: TextSpan(
             style: const TextStyle(fontSize: 16),
             children: [
-              const TextSpan(text: 'You can explore and discover new federations through '),
+              const TextSpan(
+                text: 'You can explore and discover new federations through ',
+              ),
               TextSpan(
                 text: 'Nostr',
-                style: const TextStyle(color: Colors.blue, decoration: TextDecoration.underline),
-                recognizer: TapGestureRecognizer()
-                  ..onTap = () {
-                    Navigator.push(context, MaterialPageRoute(builder: (context) => Discover(onJoin: widget.onJoin)));
-                  },
+                style: const TextStyle(
+                  color: Colors.blue,
+                  decoration: TextDecoration.underline,
+                ),
+                recognizer:
+                    TapGestureRecognizer()
+                      ..onTap = () {
+                        Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            builder:
+                                (context) => Discover(onJoin: widget.onJoin),
+                          ),
+                        );
+                      },
               ),
               const TextSpan(text: ' or by visiting '),
               TextSpan(
                 text: 'Fedimint Observer',
-                style: const TextStyle(color: Colors.blue, decoration: TextDecoration.underline),
-                recognizer: TapGestureRecognizer()
-                  ..onTap = () async {
-                    const url = 'https://observer.fedimint.org';
-                    if (await canLaunch(url)) {
-                      await launch(url);
-                    }
-                  },
+                style: const TextStyle(
+                  color: Colors.blue,
+                  decoration: TextDecoration.underline,
+                ),
+                recognizer:
+                    TapGestureRecognizer()
+                      ..onTap = () async {
+                        const url = 'https://observer.fedimint.org';
+                        if (await canLaunch(url)) {
+                          await launch(url);
+                        }
+                      },
               ),
               const TextSpan(text: '.'),
             ],
@@ -91,9 +108,19 @@ class _WelcomeWidgetState extends State<WelcomeWidget> {
                 content: Column(
                   mainAxisAlignment: MainAxisAlignment.center,
                   children: [
-                    Icon(Icons.group_add, size: 80, color: Theme.of(context).primaryColor),
+                    Icon(
+                      Icons.group_add,
+                      size: 80,
+                      color: Theme.of(context).primaryColor,
+                    ),
                     const SizedBox(height: 32),
-                    const Text('Welcome!', style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold)),
+                    const Text(
+                      'Welcome!',
+                      style: TextStyle(
+                        fontSize: 24,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
                     const SizedBox(height: 16),
                     const Text(
                       'You can join a community by scanning or copying a join code provided by a federation.',
@@ -115,7 +142,10 @@ class _WelcomeWidgetState extends State<WelcomeWidget> {
                 icon: const Icon(Icons.arrow_back),
                 onPressed: () {
                   if (_controller.page! > 0) {
-                    _controller.previousPage(duration: const Duration(milliseconds: 300), curve: Curves.easeInOut);
+                    _controller.previousPage(
+                      duration: const Duration(milliseconds: 300),
+                      curve: Curves.easeInOut,
+                    );
                   }
                 },
               ),
@@ -123,7 +153,10 @@ class _WelcomeWidgetState extends State<WelcomeWidget> {
                 icon: const Icon(Icons.arrow_forward),
                 onPressed: () {
                   if (_controller.page! < 1) {
-                    _controller.nextPage(duration: const Duration(milliseconds: 300), curve: Curves.easeInOut);
+                    _controller.nextPage(
+                      duration: const Duration(milliseconds: 300),
+                      curve: Curves.easeInOut,
+                    );
                   }
                 },
               ),
@@ -147,4 +180,3 @@ class _WelcomeWidgetState extends State<WelcomeWidget> {
     );
   }
 }
-


### PR DESCRIPTION
This change runs `dart format` on all `.dart` files except `lib/number_pad.dart` to avoid conflicts with https://github.com/fedimint/fedimint-app/pull/11.