### PR TITLE
chore: add git pre-commit hook that ensures dart formatting

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -113,6 +113,10 @@
               export ANDROID_NDK_HOME=$ANDROID_SDK_ROOT/ndk/27.0.12077973
               #export JAVA_HOME=/opt/android-studio/jbr
               export JAVA_HOME=${pkgs.jdk21}
+
+              if [ -d .git ]; then
+                ln -sf "$PWD/scripts/git-hooks/pre-commit.sh" .git/hooks/pre-commit
+              fi
 	    '';
           });
         };

--- a/scripts/git-hooks/pre-commit.sh
+++ b/scripts/git-hooks/pre-commit.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+dart format -o none --set-exit-if-changed lib/*.dart > /dev/null \
+  || {
+       echo >&2 "
+✖  Dart files aren’t formatted!
+Please run:
+
+    dart format lib/*.dart
+
+and then try committing again.
+";
+       exit 1;
+     }
+


### PR DESCRIPTION
Followup to https://github.com/fedimint/fedimint-app/pull/12#pullrequestreview-2843905300

Example output if the pre-commit hook fails

```
❯ git commit

✖  Dart files aren’t formatted!
Please run:

    dart format lib/*.dart

and then try committing again.

```

There might be a more nix-y way to accomplish this by introducing flakebox and composing the devShell with the upstream and this commit hook, but I figure we can iterate later.