### PR TITLE
feat: add on-chain refunds

### DIFF
--- a/lib/dashboard.dart
+++ b/lib/dashboard.dart
@@ -4,6 +4,7 @@ import 'package:carbine/number_pad.dart';
 import 'package:carbine/payment_selector.dart';
 import 'package:carbine/scan.dart';
 import 'package:carbine/theme.dart';
+import 'package:carbine/refund.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_speed_dial/flutter_speed_dial.dart';
 import 'package:intl/intl.dart';
@@ -171,6 +172,22 @@ class _DashboardState extends State<Dashboard> {
     _loadTransactions();
   }
 
+  void _onRefundPressed() async {
+    await Navigator.push<bool>(
+      context,
+      MaterialPageRoute(
+        builder:
+            (_) => RefundConfirmationPage(
+              fed: widget.fed,
+              balanceMsats: balanceMsats!,
+            ),
+      ),
+    );
+
+    _loadBalance();
+    _loadTransactions();
+  }
+
   @override
   Widget build(BuildContext context) {
     final name = widget.fed.federationName;
@@ -198,12 +215,20 @@ class _DashboardState extends State<Dashboard> {
             onTap: () => _scheduleAction(_onReceivePressed),
           ),
           if (balanceMsats != null && balanceMsats! > BigInt.zero)
-            SpeedDialChild(
-              child: const Icon(Icons.upload),
-              label: 'Send',
-              backgroundColor: Colors.blue,
-              onTap: () => _scheduleAction(_onSendPressed),
-            ),
+            if (_selectedPaymentType == PaymentType.onchain)
+              SpeedDialChild(
+                child: const Icon(Icons.reply),
+                label: 'Refund',
+                backgroundColor: Colors.orange,
+                onTap: () => _scheduleAction(_onRefundPressed),
+              )
+            else
+              SpeedDialChild(
+                child: const Icon(Icons.upload),
+                label: 'Send',
+                backgroundColor: Colors.blue,
+                onTap: () => _scheduleAction(_onSendPressed),
+              ),
         ],
       ),
       body: SingleChildScrollView(

--- a/lib/frb_generated.dart
+++ b/lib/frb_generated.dart
@@ -63,7 +63,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.9.0';
 
   @override
-  int get rustContentHash => -1555487335;
+  int get rustContentHash => 54802965;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -190,6 +190,11 @@ abstract class RustLibApi extends BaseApi {
     required BigInt amountMsatsWithoutFees,
   });
 
+  Future<(String, BigInt)> crateMultimintRefund({
+    required Multimint that,
+    required FederationId federationId,
+  });
+
   Future<OperationId> crateMultimintSend({
     required Multimint that,
     required FederationId federationId,
@@ -309,6 +314,8 @@ abstract class RustLibApi extends BaseApi {
     required BigInt amountMsatsWithFees,
     required BigInt amountMsatsWithoutFees,
   });
+
+  Future<(String, BigInt)> crateRefund({required FederationId federationId});
 
   Future<OperationId> crateReissueEcash({
     required FederationId federationId,
@@ -1372,6 +1379,46 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   );
 
   @override
+  Future<(String, BigInt)> crateMultimintRefund({
+    required Multimint that,
+    required FederationId federationId,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMultimint(
+            that,
+            serializer,
+          );
+          sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerFederationId(
+            federationId,
+            serializer,
+          );
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 26,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_record_string_u_64,
+          decodeErrorData: sse_decode_AnyhowException,
+        ),
+        constMeta: kCrateMultimintRefundConstMeta,
+        argValues: [that, federationId],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateMultimintRefundConstMeta => const TaskConstMeta(
+    debugName: "Multimint_refund",
+    argNames: ["that", "federationId"],
+  );
+
+  @override
   Future<OperationId> crateMultimintSend({
     required Multimint that,
     required FederationId federationId,
@@ -1393,7 +1440,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 26,
+            funcId: 27,
             port: port_,
           );
         },
@@ -1429,7 +1476,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 27,
+            funcId: 28,
             port: port_,
           );
         },
@@ -1462,7 +1509,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             that,
             serializer,
           );
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 28)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 29)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_opt_String,
@@ -1493,7 +1540,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             that,
             serializer,
           );
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 29)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 30)!;
         },
         codec: SseCodec(
           decodeSuccessData:
@@ -1526,7 +1573,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             that,
             serializer,
           );
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 30)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 31)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -1558,7 +1605,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             that,
             serializer,
           );
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 31)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 32)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_list_String,
@@ -1589,7 +1636,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             that,
             serializer,
           );
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 32)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 33)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_list_String,
@@ -1620,7 +1667,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             that,
             serializer,
           );
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 33)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 34)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -1651,7 +1698,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             that,
             serializer,
           );
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 34)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 35)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_opt_String,
@@ -1684,7 +1731,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             serializer,
           );
           sse_encode_opt_String(about, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 35)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 36)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1720,7 +1767,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             federationId,
             serializer,
           );
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 36)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 37)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1754,7 +1801,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             serializer,
           );
           sse_encode_String(federationName, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 37)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 38)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1788,7 +1835,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             serializer,
           );
           sse_encode_list_String(inviteCodes, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 38)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 39)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1821,7 +1868,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             serializer,
           );
           sse_encode_list_String(modules, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 39)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 40)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1854,7 +1901,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             serializer,
           );
           sse_encode_String(network, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 40)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 41)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1887,7 +1934,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             serializer,
           );
           sse_encode_opt_String(picture, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 41)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 42)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1926,7 +1973,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 42,
+            funcId: 43,
             port: port_,
           );
         },
@@ -1967,7 +2014,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 43,
+            funcId: 44,
             port: port_,
           );
         },
@@ -2008,7 +2055,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 44,
+            funcId: 45,
             port: port_,
           );
         },
@@ -2049,7 +2096,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 45,
+            funcId: 46,
             port: port_,
           );
         },
@@ -2083,7 +2130,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 46,
+            funcId: 47,
             port: port_,
           );
         },
@@ -2110,7 +2157,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 47,
+            funcId: 48,
             port: port_,
           );
         },
@@ -2141,7 +2188,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 48,
+            funcId: 49,
             port: port_,
           );
         },
@@ -2172,7 +2219,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 49,
+            funcId: 50,
             port: port_,
           );
         },
@@ -2200,7 +2247,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 50,
+            funcId: 51,
             port: port_,
           );
         },
@@ -2233,7 +2280,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 51,
+            funcId: 52,
             port: port_,
           );
         },
@@ -2272,7 +2319,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 52,
+            funcId: 53,
             port: port_,
           );
         },
@@ -2311,7 +2358,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 53,
+            funcId: 54,
             port: port_,
           );
         },
@@ -2333,6 +2380,37 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   );
 
   @override
+  Future<(String, BigInt)> crateRefund({required FederationId federationId}) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerFederationId(
+            federationId,
+            serializer,
+          );
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 55,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_record_string_u_64,
+          decodeErrorData: sse_decode_AnyhowException,
+        ),
+        constMeta: kCrateRefundConstMeta,
+        argValues: [federationId],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateRefundConstMeta =>
+      const TaskConstMeta(debugName: "refund", argNames: ["federationId"]);
+
+  @override
   Future<OperationId> crateReissueEcash({
     required FederationId federationId,
     required String ecash,
@@ -2349,7 +2427,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 54,
+            funcId: 56,
             port: port_,
           );
         },
@@ -2387,7 +2465,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 55,
+            funcId: 57,
             port: port_,
           );
         },
@@ -2424,7 +2502,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 56,
+            funcId: 58,
             port: port_,
           );
         },
@@ -2462,7 +2540,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 57,
+            funcId: 59,
             port: port_,
           );
         },
@@ -2502,7 +2580,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 58,
+            funcId: 60,
             port: port_,
           );
         },
@@ -2544,7 +2622,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 59,
+            funcId: 61,
             port: port_,
           );
         },
@@ -3232,6 +3310,16 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       dco_decode_String(arr[3]),
       dco_decode_u_64(arr[4]),
     );
+  }
+
+  @protected
+  (String, BigInt) dco_decode_record_string_u_64(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 2) {
+      throw Exception('Expected 2 elements, got ${arr.length}');
+    }
+    return (dco_decode_String(arr[0]), dco_decode_u_64(arr[1]));
   }
 
   @protected
@@ -3979,6 +4067,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     var var_field3 = sse_decode_String(deserializer);
     var var_field4 = sse_decode_u_64(deserializer);
     return (var_field0, var_field1, var_field2, var_field3, var_field4);
+  }
+
+  @protected
+  (String, BigInt) sse_decode_record_string_u_64(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_field0 = sse_decode_String(deserializer);
+    var var_field1 = sse_decode_u_64(deserializer);
+    return (var_field0, var_field1);
   }
 
   @protected
@@ -4750,6 +4846,16 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  void sse_encode_record_string_u_64(
+    (String, BigInt) self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_String(self.$1, serializer);
+    sse_encode_u_64(self.$2, serializer);
+  }
+
+  @protected
   void sse_encode_record_string_u_64_u_64_u_64(
     (String, BigInt, BigInt, BigInt) self,
     SseSerializer serializer,
@@ -5156,6 +5262,16 @@ class MultimintImpl extends RustOpaque implements Multimint {
     amountMsatsWithFees: amountMsatsWithFees,
     amountMsatsWithoutFees: amountMsatsWithoutFees,
   );
+
+  /// Refund the full balance on-chain to the Mutinynet faucet.
+  ///
+  /// This is a temporary method that assists with development and should
+  /// be removed before supporting mainnet.
+  Future<(String, BigInt)> refund({required FederationId federationId}) =>
+      RustLib.instance.api.crateMultimintRefund(
+        that: this,
+        federationId: federationId,
+      );
 
   Future<OperationId> send({
     required FederationId federationId,

--- a/lib/frb_generated.io.dart
+++ b/lib/frb_generated.io.dart
@@ -373,6 +373,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  (String, BigInt) dco_decode_record_string_u_64(dynamic raw);
+
+  @protected
   (String, BigInt, BigInt, BigInt) dco_decode_record_string_u_64_u_64_u_64(
     dynamic raw,
   );
@@ -691,6 +694,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   sse_decode_record_string_auto_owned_rust_opaque_flutter_rust_bridgefor_generated_rust_auto_opaque_inner_operation_id_string_string_u_64(
     SseDeserializer deserializer,
   );
+
+  @protected
+  (String, BigInt) sse_decode_record_string_u_64(SseDeserializer deserializer);
 
   @protected
   (String, BigInt, BigInt, BigInt) sse_decode_record_string_u_64_u_64_u_64(
@@ -1073,6 +1079,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   void
   sse_encode_record_string_auto_owned_rust_opaque_flutter_rust_bridgefor_generated_rust_auto_opaque_inner_operation_id_string_string_u_64(
     (String, OperationId, String, String, BigInt) self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_record_string_u_64(
+    (String, BigInt) self,
     SseSerializer serializer,
   );
 

--- a/lib/frb_generated.web.dart
+++ b/lib/frb_generated.web.dart
@@ -375,6 +375,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  (String, BigInt) dco_decode_record_string_u_64(dynamic raw);
+
+  @protected
   (String, BigInt, BigInt, BigInt) dco_decode_record_string_u_64_u_64_u_64(
     dynamic raw,
   );
@@ -693,6 +696,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   sse_decode_record_string_auto_owned_rust_opaque_flutter_rust_bridgefor_generated_rust_auto_opaque_inner_operation_id_string_string_u_64(
     SseDeserializer deserializer,
   );
+
+  @protected
+  (String, BigInt) sse_decode_record_string_u_64(SseDeserializer deserializer);
 
   @protected
   (String, BigInt, BigInt, BigInt) sse_decode_record_string_u_64_u_64_u_64(
@@ -1075,6 +1081,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   void
   sse_encode_record_string_auto_owned_rust_opaque_flutter_rust_bridgefor_generated_rust_auto_opaque_inner_operation_id_string_string_u_64(
     (String, OperationId, String, String, BigInt) self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_record_string_u_64(
+    (String, BigInt) self,
     SseSerializer serializer,
   );
 

--- a/lib/lib.dart
+++ b/lib/lib.dart
@@ -135,6 +135,9 @@ Future<ReissueExternalNotesState> awaitEcashReissue({
   operationId: operationId,
 );
 
+Future<(String, BigInt)> refund({required FederationId federationId}) =>
+    RustLib.instance.api.crateRefund(federationId: federationId);
+
 // Rust type: RustOpaqueMoi<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<Bolt11Invoice>>
 abstract class Bolt11Invoice implements RustOpaqueInterface {}
 
@@ -202,6 +205,12 @@ abstract class Multimint implements RustOpaqueInterface {
     required BigInt amountMsatsWithFees,
     required BigInt amountMsatsWithoutFees,
   });
+
+  /// Refund the full balance on-chain to the Mutinynet faucet.
+  ///
+  /// This is a temporary method that assists with development and should
+  /// be removed before supporting mainnet.
+  Future<(String, BigInt)> refund({required FederationId federationId});
 
   Future<OperationId> send({
     required FederationId federationId,

--- a/lib/number_pad.dart
+++ b/lib/number_pad.dart
@@ -135,26 +135,36 @@ class _NumberPadState extends State<NumberPad> {
       }
 
       String digit = '';
-      if (key == LogicalKeyboardKey.digit0 || key == LogicalKeyboardKey.numpad0)
+      if (key == LogicalKeyboardKey.digit0 || key == LogicalKeyboardKey.numpad0) {
         digit = '0';
-      if (key == LogicalKeyboardKey.digit1 || key == LogicalKeyboardKey.numpad1)
+      }
+      if (key == LogicalKeyboardKey.digit1 || key == LogicalKeyboardKey.numpad1) {
         digit = '1';
-      if (key == LogicalKeyboardKey.digit2 || key == LogicalKeyboardKey.numpad2)
+      }
+      if (key == LogicalKeyboardKey.digit2 || key == LogicalKeyboardKey.numpad2) {
         digit = '2';
-      if (key == LogicalKeyboardKey.digit3 || key == LogicalKeyboardKey.numpad3)
+      }
+      if (key == LogicalKeyboardKey.digit3 || key == LogicalKeyboardKey.numpad3) {
         digit = '3';
-      if (key == LogicalKeyboardKey.digit4 || key == LogicalKeyboardKey.numpad4)
+      }
+      if (key == LogicalKeyboardKey.digit4 || key == LogicalKeyboardKey.numpad4) {
         digit = '4';
-      if (key == LogicalKeyboardKey.digit5 || key == LogicalKeyboardKey.numpad5)
+      }
+      if (key == LogicalKeyboardKey.digit5 || key == LogicalKeyboardKey.numpad5) {
         digit = '5';
-      if (key == LogicalKeyboardKey.digit6 || key == LogicalKeyboardKey.numpad6)
+      }
+      if (key == LogicalKeyboardKey.digit6 || key == LogicalKeyboardKey.numpad6) {
         digit = '6';
-      if (key == LogicalKeyboardKey.digit7 || key == LogicalKeyboardKey.numpad7)
+      }
+      if (key == LogicalKeyboardKey.digit7 || key == LogicalKeyboardKey.numpad7) {
         digit = '7';
-      if (key == LogicalKeyboardKey.digit8 || key == LogicalKeyboardKey.numpad8)
+      }
+      if (key == LogicalKeyboardKey.digit8 || key == LogicalKeyboardKey.numpad8) {
         digit = '8';
-      if (key == LogicalKeyboardKey.digit9 || key == LogicalKeyboardKey.numpad9)
+      }
+      if (key == LogicalKeyboardKey.digit9 || key == LogicalKeyboardKey.numpad9) {
         digit = '9';
+      }
       if (key == LogicalKeyboardKey.backspace) {
         setState(() {
           if (_rawAmount.isNotEmpty) {

--- a/lib/refund.dart
+++ b/lib/refund.dart
@@ -1,0 +1,82 @@
+import 'package:carbine/success.dart';
+import 'package:flutter/material.dart';
+import 'package:carbine/lib.dart';
+
+/// A simple confirmation page for refunding the full on-chain balance
+class RefundConfirmationPage extends StatelessWidget {
+  final FederationSelector fed;
+  final BigInt balanceMsats;
+
+  // Static refund address
+  static const String refundAddress =
+      'tb1qd28npep0s8frcm3y7dxqajkcy2m40eysplyr9v';
+
+  const RefundConfirmationPage({
+    super.key,
+    required this.fed,
+    required this.balanceMsats,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    // Convert msats to sats
+    final sats = balanceMsats ~/ BigInt.from(1000);
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Confirm Refund'), centerTitle: true),
+      body: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Text(
+              'You are about to send your full balance of $sats sats to:',
+              textAlign: TextAlign.center,
+              style: Theme.of(context).textTheme.bodyLarge,
+            ),
+            const SizedBox(height: 12),
+            SelectableText(
+              refundAddress,
+              textAlign: TextAlign.center,
+              style: Theme.of(
+                context,
+              ).textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.w600),
+            ),
+            const SizedBox(height: 24),
+            ElevatedButton(
+              onPressed: () async {
+                final navigator = Navigator.of(context);
+                final rootNav = Navigator.of(context, rootNavigator: true);
+
+                await refund(federationId: fed.federationId);
+
+                navigator.push(
+                  MaterialPageRoute(
+                    builder:
+                        (context) => Success(
+                          lightning: true,
+                          received: false,
+                          amountMsats: balanceMsats,
+                        ),
+                  ),
+                );
+
+                await Future.delayed(const Duration(seconds: 4));
+                rootNav.popUntil((route) => route.isFirst);
+              },
+              child: const Text('Confirm'),
+            ),
+            const SizedBox(height: 12),
+            TextButton(
+              onPressed: () {
+                Navigator.of(context).pop(false);
+              },
+              child: const Text('Cancel'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/rust/carbine_fedimint/Cargo.lock
+++ b/rust/carbine_fedimint/Cargo.lock
@@ -769,6 +769,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "bitcoin",
  "fedimint-api-client",
  "fedimint-bip39",
  "fedimint-client",

--- a/rust/carbine_fedimint/Cargo.toml
+++ b/rust/carbine_fedimint/Cargo.toml
@@ -9,6 +9,7 @@ crate-type = ["cdylib"]
 [dependencies]
 anyhow = "1.0.97"
 async-trait = "0.1.88"
+bitcoin = { version = "0.32.5", features = ["serde"] }
 fedimint-api-client = "0.7.0"
 fedimint-bip39 = "0.7.0"
 fedimint-core = "0.7.0"

--- a/rust/carbine_fedimint/src/frb_generated.rs
+++ b/rust/carbine_fedimint/src/frb_generated.rs
@@ -39,7 +39,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.9.0";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -1555487335;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 54802965;
 
 // Section: executor
 
@@ -1370,6 +1370,79 @@ fn wire__crate__Multimint_receive_impl(
                             api_amount_msats_without_fees,
                         )
                         .await?;
+                        Ok(output_ok)
+                    })()
+                    .await,
+                )
+            }
+        },
+    )
+}
+fn wire__crate__Multimint_refund_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec, _, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "Multimint_refund",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_that = <RustOpaqueMoi<
+                flutter_rust_bridge::for_generated::RustAutoOpaqueInner<Multimint>,
+            >>::sse_decode(&mut deserializer);
+            let api_federation_id = <RustOpaqueMoi<
+                flutter_rust_bridge::for_generated::RustAutoOpaqueInner<FederationId>,
+            >>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| async move {
+                transform_result_sse::<_, flutter_rust_bridge::for_generated::anyhow::Error>(
+                    (move || async move {
+                        let mut api_that_guard = None;
+                        let mut api_federation_id_guard = None;
+                        let decode_indices_ =
+                            flutter_rust_bridge::for_generated::lockable_compute_decode_order(
+                                vec![
+                                    flutter_rust_bridge::for_generated::LockableOrderInfo::new(
+                                        &api_that, 0, false,
+                                    ),
+                                    flutter_rust_bridge::for_generated::LockableOrderInfo::new(
+                                        &api_federation_id,
+                                        1,
+                                        false,
+                                    ),
+                                ],
+                            );
+                        for i in decode_indices_ {
+                            match i {
+                                0 => {
+                                    api_that_guard =
+                                        Some(api_that.lockable_decode_async_ref().await)
+                                }
+                                1 => {
+                                    api_federation_id_guard =
+                                        Some(api_federation_id.lockable_decode_async_ref().await)
+                                }
+                                _ => unreachable!(),
+                            }
+                        }
+                        let api_that_guard = api_that_guard.unwrap();
+                        let api_federation_id_guard = api_federation_id_guard.unwrap();
+                        let output_ok =
+                            crate::Multimint::refund(&*api_that_guard, &*api_federation_id_guard)
+                                .await?;
                         Ok(output_ok)
                     })()
                     .await,
@@ -2795,6 +2868,63 @@ fn wire__crate__receive_impl(
         },
     )
 }
+fn wire__crate__refund_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec, _, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "refund",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_federation_id = <RustOpaqueMoi<
+                flutter_rust_bridge::for_generated::RustAutoOpaqueInner<FederationId>,
+            >>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| async move {
+                transform_result_sse::<_, flutter_rust_bridge::for_generated::anyhow::Error>(
+                    (move || async move {
+                        let mut api_federation_id_guard = None;
+                        let decode_indices_ =
+                            flutter_rust_bridge::for_generated::lockable_compute_decode_order(
+                                vec![flutter_rust_bridge::for_generated::LockableOrderInfo::new(
+                                    &api_federation_id,
+                                    0,
+                                    false,
+                                )],
+                            );
+                        for i in decode_indices_ {
+                            match i {
+                                0 => {
+                                    api_federation_id_guard =
+                                        Some(api_federation_id.lockable_decode_async_ref().await)
+                                }
+                                _ => unreachable!(),
+                            }
+                        }
+                        let api_federation_id_guard = api_federation_id_guard.unwrap();
+                        let output_ok = crate::refund(&*api_federation_id_guard).await?;
+                        Ok(output_ok)
+                    })()
+                    .await,
+                )
+            }
+        },
+    )
+}
 fn wire__crate__reissue_ecash_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
@@ -3717,6 +3847,15 @@ impl SseDecode for (String, OperationId, String, String, u64) {
     }
 }
 
+impl SseDecode for (String, u64) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_field0 = <String>::sse_decode(deserializer);
+        let mut var_field1 = <u64>::sse_decode(deserializer);
+        return (var_field0, var_field1);
+    }
+}
+
 impl SseDecode for (String, u64, u64, u64) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -3795,31 +3934,33 @@ fn pde_ffi_dispatcher_primary_impl(
         23 => wire__crate__Multimint_join_federation_impl(port, ptr, rust_vec_len, data_len),
         24 => wire__crate__Multimint_new_impl(port, ptr, rust_vec_len, data_len),
         25 => wire__crate__Multimint_receive_impl(port, ptr, rust_vec_len, data_len),
-        26 => wire__crate__Multimint_send_impl(port, ptr, rust_vec_len, data_len),
-        27 => wire__crate__Multimint_update_federations_from_nostr_impl(
+        26 => wire__crate__Multimint_refund_impl(port, ptr, rust_vec_len, data_len),
+        27 => wire__crate__Multimint_send_impl(port, ptr, rust_vec_len, data_len),
+        28 => wire__crate__Multimint_update_federations_from_nostr_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        42 => wire__crate__await_ecash_reissue_impl(port, ptr, rust_vec_len, data_len),
-        43 => wire__crate__await_ecash_send_impl(port, ptr, rust_vec_len, data_len),
-        44 => wire__crate__await_receive_impl(port, ptr, rust_vec_len, data_len),
-        45 => wire__crate__await_send_impl(port, ptr, rust_vec_len, data_len),
-        46 => wire__crate__balance_impl(port, ptr, rust_vec_len, data_len),
-        47 => wire__crate__federations_impl(port, ptr, rust_vec_len, data_len),
-        48 => wire__crate__get_federation_meta_impl(port, ptr, rust_vec_len, data_len),
-        49 => wire__crate__init_multimint_impl(port, ptr, rust_vec_len, data_len),
-        50 => wire__crate__join_federation_impl(port, ptr, rust_vec_len, data_len),
-        51 => wire__crate__list_federations_from_nostr_impl(port, ptr, rust_vec_len, data_len),
-        52 => wire__crate__payment_preview_impl(port, ptr, rust_vec_len, data_len),
-        53 => wire__crate__receive_impl(port, ptr, rust_vec_len, data_len),
-        54 => wire__crate__reissue_ecash_impl(port, ptr, rust_vec_len, data_len),
-        55 => wire__crate__select_receive_gateway_impl(port, ptr, rust_vec_len, data_len),
-        56 => wire__crate__send_impl(port, ptr, rust_vec_len, data_len),
-        57 => wire__crate__send_ecash_impl(port, ptr, rust_vec_len, data_len),
-        58 => wire__crate__send_lnaddress_impl(port, ptr, rust_vec_len, data_len),
-        59 => wire__crate__transactions_impl(port, ptr, rust_vec_len, data_len),
+        43 => wire__crate__await_ecash_reissue_impl(port, ptr, rust_vec_len, data_len),
+        44 => wire__crate__await_ecash_send_impl(port, ptr, rust_vec_len, data_len),
+        45 => wire__crate__await_receive_impl(port, ptr, rust_vec_len, data_len),
+        46 => wire__crate__await_send_impl(port, ptr, rust_vec_len, data_len),
+        47 => wire__crate__balance_impl(port, ptr, rust_vec_len, data_len),
+        48 => wire__crate__federations_impl(port, ptr, rust_vec_len, data_len),
+        49 => wire__crate__get_federation_meta_impl(port, ptr, rust_vec_len, data_len),
+        50 => wire__crate__init_multimint_impl(port, ptr, rust_vec_len, data_len),
+        51 => wire__crate__join_federation_impl(port, ptr, rust_vec_len, data_len),
+        52 => wire__crate__list_federations_from_nostr_impl(port, ptr, rust_vec_len, data_len),
+        53 => wire__crate__payment_preview_impl(port, ptr, rust_vec_len, data_len),
+        54 => wire__crate__receive_impl(port, ptr, rust_vec_len, data_len),
+        55 => wire__crate__refund_impl(port, ptr, rust_vec_len, data_len),
+        56 => wire__crate__reissue_ecash_impl(port, ptr, rust_vec_len, data_len),
+        57 => wire__crate__select_receive_gateway_impl(port, ptr, rust_vec_len, data_len),
+        58 => wire__crate__send_impl(port, ptr, rust_vec_len, data_len),
+        59 => wire__crate__send_ecash_impl(port, ptr, rust_vec_len, data_len),
+        60 => wire__crate__send_lnaddress_impl(port, ptr, rust_vec_len, data_len),
+        61 => wire__crate__transactions_impl(port, ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }
@@ -3922,68 +4063,68 @@ fn pde_ffi_dispatcher_sync_impl(
             rust_vec_len,
             data_len,
         ),
-        28 => {
+        29 => {
             wire__crate__PublicFederation_auto_accessor_get_about_impl(ptr, rust_vec_len, data_len)
         }
-        29 => wire__crate__PublicFederation_auto_accessor_get_federation_id_impl(
+        30 => wire__crate__PublicFederation_auto_accessor_get_federation_id_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        30 => wire__crate__PublicFederation_auto_accessor_get_federation_name_impl(
+        31 => wire__crate__PublicFederation_auto_accessor_get_federation_name_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        31 => wire__crate__PublicFederation_auto_accessor_get_invite_codes_impl(
+        32 => wire__crate__PublicFederation_auto_accessor_get_invite_codes_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        32 => wire__crate__PublicFederation_auto_accessor_get_modules_impl(
+        33 => wire__crate__PublicFederation_auto_accessor_get_modules_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        33 => wire__crate__PublicFederation_auto_accessor_get_network_impl(
+        34 => wire__crate__PublicFederation_auto_accessor_get_network_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        34 => wire__crate__PublicFederation_auto_accessor_get_picture_impl(
+        35 => wire__crate__PublicFederation_auto_accessor_get_picture_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        35 => {
+        36 => {
             wire__crate__PublicFederation_auto_accessor_set_about_impl(ptr, rust_vec_len, data_len)
         }
-        36 => wire__crate__PublicFederation_auto_accessor_set_federation_id_impl(
+        37 => wire__crate__PublicFederation_auto_accessor_set_federation_id_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        37 => wire__crate__PublicFederation_auto_accessor_set_federation_name_impl(
+        38 => wire__crate__PublicFederation_auto_accessor_set_federation_name_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        38 => wire__crate__PublicFederation_auto_accessor_set_invite_codes_impl(
+        39 => wire__crate__PublicFederation_auto_accessor_set_invite_codes_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        39 => wire__crate__PublicFederation_auto_accessor_set_modules_impl(
+        40 => wire__crate__PublicFederation_auto_accessor_set_modules_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        40 => wire__crate__PublicFederation_auto_accessor_set_network_impl(
+        41 => wire__crate__PublicFederation_auto_accessor_set_network_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        41 => wire__crate__PublicFederation_auto_accessor_set_picture_impl(
+        42 => wire__crate__PublicFederation_auto_accessor_set_picture_impl(
             ptr,
             rust_vec_len,
             data_len,
@@ -4745,6 +4886,14 @@ impl SseEncode for (String, OperationId, String, String, u64) {
         <String>::sse_encode(self.2, serializer);
         <String>::sse_encode(self.3, serializer);
         <u64>::sse_encode(self.4, serializer);
+    }
+}
+
+impl SseEncode for (String, u64) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <String>::sse_encode(self.0, serializer);
+        <u64>::sse_encode(self.1, serializer);
     }
 }
 

--- a/rust/carbine_fedimint/src/lib.rs
+++ b/rust/carbine_fedimint/src/lib.rs
@@ -11,6 +11,7 @@ use fedimint_lnv2_common::config::LightningClientConfig;
 use fedimint_lnv2_common::gateway_api::PaymentFee;
 use fedimint_meta_client::common::DEFAULT_META_KEY;
 use fedimint_meta_client::MetaClientInit;
+use fedimint_wallet_client::WithdrawState;
 /* AUTO INJECTED BY flutter_rust_bridge. This line may not be accurate, and you can change it according to your needs. */
 use flutter_rust_bridge::frb;
 use serde_json::to_value;
@@ -20,7 +21,7 @@ use std::path::PathBuf;
 use std::time::UNIX_EPOCH;
 use std::{collections::BTreeMap, fmt::Display, str::FromStr, sync::Arc, time::Duration};
 
-use anyhow::{anyhow, bail};
+use anyhow::{anyhow, bail, Context};
 use fedimint_api_client::api::net::Connector;
 use fedimint_bip39::{Bip39RootSecretStrategy, Mnemonic};
 use fedimint_client::{
@@ -152,13 +153,19 @@ pub async fn select_receive_gateway(
 }
 
 #[frb]
-pub async fn send_lnaddress(federation_id: &FederationId, amount_msats: u64, address: String) -> anyhow::Result<OperationId> {
+pub async fn send_lnaddress(
+    federation_id: &FederationId,
+    amount_msats: u64,
+    address: String,
+) -> anyhow::Result<OperationId> {
     let lnurl = lnurl::lightning_address::LightningAddress::from_str(&address)?.lnurl();
     let async_client = lnurl::AsyncClient::from_client(reqwest::Client::new());
     let response = async_client.make_request(&lnurl.url).await?;
     match response {
         lnurl::LnUrlResponse::LnUrlPayResponse(response) => {
-            let invoice = async_client.get_invoice(&response, amount_msats, None, None).await?;
+            let invoice = async_client
+                .get_invoice(&response, amount_msats, None, None)
+                .await?;
 
             let multimint = get_multimint().await;
             let mm = multimint.read().await;
@@ -212,7 +219,10 @@ pub async fn list_federations_from_nostr(force_update: bool) -> Vec<PublicFedera
 }
 
 #[frb]
-pub async fn payment_preview(federation_id: &FederationId, bolt11: String) -> anyhow::Result<PaymentPreview> {
+pub async fn payment_preview(
+    federation_id: &FederationId,
+    bolt11: String,
+) -> anyhow::Result<PaymentPreview> {
     let invoice = Bolt11Invoice::from_str(&bolt11)?;
     let amount_msats = invoice
         .amount_milli_satoshis()
@@ -222,7 +232,9 @@ pub async fn payment_preview(federation_id: &FederationId, bolt11: String) -> an
 
     let multimint = get_multimint().await;
     let mm = multimint.read().await;
-    let (gateway, fee_base, fee_ppm, fed_fee) = mm.select_send_gateway(federation_id, Amount::from_msats(amount_msats)).await?;
+    let (gateway, fee_base, fee_ppm, fed_fee) = mm
+        .select_send_gateway(federation_id, Amount::from_msats(amount_msats))
+        .await?;
 
     Ok(PaymentPreview {
         amount_msats,
@@ -296,6 +308,13 @@ pub async fn await_ecash_reissue(
     let multimint = get_multimint().await;
     let mm = multimint.read().await;
     mm.await_ecash_reissue(federation_id, operation_id).await
+}
+
+#[frb]
+pub async fn refund(federation_id: &FederationId) -> anyhow::Result<(String, u64)> {
+    let multimint = get_multimint().await;
+    let mm = multimint.read().await;
+    mm.refund(federation_id).await
 }
 
 #[derive(Clone, Eq, PartialEq, Serialize, Debug)]
@@ -898,7 +917,9 @@ impl Multimint {
             .clients
             .get(federation_id)
             .expect("No federation exists");
-        if let Ok((url, receive_fee, fed_fee)) = Self::lnv2_select_gateway(client, amount, true).await {
+        if let Ok((url, receive_fee, fed_fee)) =
+            Self::lnv2_select_gateway(client, amount, true).await
+        {
             return Ok((
                 url.to_string(),
                 receive_fee.base.msats,
@@ -923,7 +944,8 @@ impl Multimint {
             .clients
             .get(federation_id)
             .expect("No federation exists");
-        if let Ok((url, send_fee, fed_fee)) = Self::lnv2_select_gateway(client, amount, false).await {
+        if let Ok((url, send_fee, fed_fee)) = Self::lnv2_select_gateway(client, amount, false).await
+        {
             return Ok((
                 url.to_string(),
                 send_fee.base.msats,
@@ -936,7 +958,12 @@ impl Multimint {
         let gateway = Self::lnv1_select_gateway(client)
             .await
             .ok_or(anyhow!("No available gateways"))?;
-        Ok((gateway.api.to_string(), gateway.fees.base_msat as u64, gateway.fees.proportional_millionths as u64, 0))
+        Ok((
+            gateway.api.to_string(),
+            gateway.fees.base_msat as u64,
+            gateway.fees.proportional_millionths as u64,
+            0,
+        ))
     }
 
     pub async fn send(
@@ -1209,14 +1236,16 @@ impl Multimint {
         // TODO: Lnv2 currently has no exposed way of querying gateways
         // Just add placeholder here
         let (url, fee) = if is_receive {
-            let url = SafeUrl::parse("https://mutinynet.mplsfed.xyz").expect("could not parse SafeUrl");
+            let url =
+                SafeUrl::parse("https://mutinynet.mplsfed.xyz").expect("could not parse SafeUrl");
             let receive_fee = PaymentFee {
                 base: Amount::from_msats(0),
                 parts_per_million: 0,
             };
             (url, receive_fee)
         } else {
-            let url = SafeUrl::parse("https://mutinynet.mplsfed.xyz").expect("could not parse SafeUrl");
+            let url =
+                SafeUrl::parse("https://mutinynet.mplsfed.xyz").expect("could not parse SafeUrl");
             let send_fee = PaymentFee {
                 base: Amount::from_msats(0),
                 parts_per_million: 0,
@@ -1484,5 +1513,63 @@ impl Multimint {
         }
 
         Ok(final_state)
+    }
+
+    /// Refund the full balance on-chain to the Mutinynet faucet.
+    ///
+    /// This is a temporary method that assists with development and should
+    /// be removed before supporting mainnet.
+    pub async fn refund(&self, federation_id: &FederationId) -> anyhow::Result<(String, u64)> {
+        // hardcoded address for the Mutinynet faucet
+        // https://faucet.mutinynet.com/
+        let address =
+            bitcoin::address::Address::from_str("tb1qd28npep0s8frcm3y7dxqajkcy2m40eysplyr9v")?;
+
+        let client = self
+            .clients
+            .get(federation_id)
+            .expect("No federation exists");
+        let wallet_module =
+            client.get_first_module::<fedimint_wallet_client::WalletClientModule>()?;
+
+        let address = address.require_network(wallet_module.get_network())?;
+        let balance = bitcoin::Amount::from_sat(client.get_balance().await.msats / 1000);
+        let fees = wallet_module.get_withdraw_fees(&address, balance).await?;
+        let absolute_fees = fees.amount();
+        let amount = balance
+            .checked_sub(fees.amount())
+            .context("Not enough funds to pay fees")?;
+
+        println!("Attempting withdraw with fees: {fees:?}");
+
+        let operation_id = wallet_module.withdraw(&address, amount, fees, ()).await?;
+
+        let mut updates = wallet_module
+            .subscribe_withdraw_updates(operation_id)
+            .await?
+            .into_stream();
+
+        let (txid, fees_sat) = loop {
+            let update = updates
+                .next()
+                .await
+                .ok_or_else(|| anyhow!("Update stream ended without outcome"))?;
+
+            println!("Withdraw state update: {:?}", update);
+
+            match update {
+                WithdrawState::Succeeded(txid) => {
+                    break (txid.consensus_encode_to_hex(), absolute_fees.to_sat());
+                }
+                WithdrawState::Failed(e) => {
+                    bail!("Withdraw failed: {e}");
+                }
+                WithdrawState::Created => {
+                    continue;
+                }
+            }
+        };
+
+        Ok((txid, fees_sat))
     }
 }


### PR DESCRIPTION
Adds a refund button for on-chain that sends the wallet's full balance back to the Mutinynet faucet. This is intended to be a temporary feature meant to aid development workflows.

This single commit is a bit sloppy and includes a few other refactors, so let me know if it's preferred to separate the refactors from the additions.