### PR TITLE
feat: add redeem ecash screen

### DIFF
--- a/lib/ecash_send.dart
+++ b/lib/ecash_send.dart
@@ -110,6 +110,7 @@ class _EcashSendState extends State<EcashSend> {
     );
   }
 
+  // TODO: Remove this, it is confusing when sending
   String _abbreviate(String text, [int max = 30]) {
     if (text.length <= max) return text;
     return '${text.substring(0, 10)}...${text.substring(text.length - 10)}';

--- a/lib/frb_generated.dart
+++ b/lib/frb_generated.dart
@@ -63,7 +63,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.9.0';
 
   @override
-  int get rustContentHash => -1555487335;
+  int get rustContentHash => -2020551964;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -297,6 +297,11 @@ abstract class RustLibApi extends BaseApi {
 
   Future<List<PublicFederation>> crateListFederationsFromNostr({
     required bool forceUpdate,
+  });
+
+  Future<BigInt> crateParseEcash({
+    required FederationId federationId,
+    required String ecash,
   });
 
   Future<PaymentPreview> cratePaymentPreview({
@@ -2256,6 +2261,43 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
+  Future<BigInt> crateParseEcash({
+    required FederationId federationId,
+    required String ecash,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerFederationId(
+            federationId,
+            serializer,
+          );
+          sse_encode_String(ecash, serializer);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 52,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_u_64,
+          decodeErrorData: sse_decode_AnyhowException,
+        ),
+        constMeta: kCrateParseEcashConstMeta,
+        argValues: [federationId, ecash],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateParseEcashConstMeta => const TaskConstMeta(
+    debugName: "parse_ecash",
+    argNames: ["federationId", "ecash"],
+  );
+
+  @override
   Future<PaymentPreview> cratePaymentPreview({
     required FederationId federationId,
     required String bolt11,
@@ -2272,7 +2314,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 52,
+            funcId: 53,
             port: port_,
           );
         },
@@ -2311,7 +2353,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 53,
+            funcId: 54,
             port: port_,
           );
         },
@@ -2349,7 +2391,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 54,
+            funcId: 55,
             port: port_,
           );
         },
@@ -2387,7 +2429,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 55,
+            funcId: 56,
             port: port_,
           );
         },
@@ -2424,7 +2466,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 56,
+            funcId: 57,
             port: port_,
           );
         },
@@ -2462,7 +2504,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 57,
+            funcId: 58,
             port: port_,
           );
         },
@@ -2502,7 +2544,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 58,
+            funcId: 59,
             port: port_,
           );
         },
@@ -2544,7 +2586,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 59,
+            funcId: 60,
             port: port_,
           );
         },

--- a/lib/lib.dart
+++ b/lib/lib.dart
@@ -6,7 +6,7 @@
 import 'frb_generated.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 
-// These functions are ignored because they are not marked as `pub`: `add_relay`, `await_ecash_reissue`, `await_ecash_send`, `await_receive_lnv1`, `await_receive_lnv2`, `await_send_lnv1`, `await_send_lnv2`, `build_client`, `create_nostr_client`, `derive_federation_secret`, `get_client_database`, `get_federation_meta`, `get_multimint`, `has_federation`, `lnv1_select_gateway`, `lnv1_update_gateway_cache`, `lnv2_select_gateway`, `load_clients`, `parse_content`, `parse_federation_id`, `parse_federation_name`, `parse_invite_codes`, `parse_modules`, `parse_network`, `parse_picture`, `pay_lnv1`, `pay_lnv2`, `receive_lnv1`, `receive_lnv2`, `reissue_ecash`, `select_receive_gateway`, `select_send_gateway`, `send_ecash`, `transactions`
+// These functions are ignored because they are not marked as `pub`: `add_relay`, `await_ecash_reissue`, `await_ecash_send`, `await_receive_lnv1`, `await_receive_lnv2`, `await_send_lnv1`, `await_send_lnv2`, `build_client`, `create_nostr_client`, `derive_federation_secret`, `get_client_database`, `get_federation_meta`, `get_multimint`, `has_federation`, `lnv1_select_gateway`, `lnv1_update_gateway_cache`, `lnv2_select_gateway`, `load_clients`, `parse_content`, `parse_ecash`, `parse_federation_id`, `parse_federation_name`, `parse_invite_codes`, `parse_modules`, `parse_network`, `parse_picture`, `pay_lnv1`, `pay_lnv2`, `receive_lnv1`, `receive_lnv2`, `reissue_ecash`, `select_receive_gateway`, `select_send_gateway`, `send_ecash`, `transactions`
 // These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `clone`, `clone`, `clone`, `clone`, `eq`, `eq`, `eq`, `eq`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `try_from`
 
 Future<void> initMultimint({required String path}) =>
@@ -117,6 +117,14 @@ Future<SpendOobState> awaitEcashSend({
 }) => RustLib.instance.api.crateAwaitEcashSend(
   federationId: federationId,
   operationId: operationId,
+);
+
+Future<BigInt> parseEcash({
+  required FederationId federationId,
+  required String ecash,
+}) => RustLib.instance.api.crateParseEcash(
+  federationId: federationId,
+  ecash: ecash,
 );
 
 Future<OperationId> reissueEcash({

--- a/lib/number_pad.dart
+++ b/lib/number_pad.dart
@@ -135,26 +135,46 @@ class _NumberPadState extends State<NumberPad> {
       }
 
       String digit = '';
-      if (key == LogicalKeyboardKey.digit0 || key == LogicalKeyboardKey.numpad0)
+      if (key == LogicalKeyboardKey.digit0 ||
+          key == LogicalKeyboardKey.numpad0) {
         digit = '0';
-      if (key == LogicalKeyboardKey.digit1 || key == LogicalKeyboardKey.numpad1)
+      }
+      if (key == LogicalKeyboardKey.digit1 ||
+          key == LogicalKeyboardKey.numpad1) {
         digit = '1';
-      if (key == LogicalKeyboardKey.digit2 || key == LogicalKeyboardKey.numpad2)
+      }
+      if (key == LogicalKeyboardKey.digit2 ||
+          key == LogicalKeyboardKey.numpad2) {
         digit = '2';
-      if (key == LogicalKeyboardKey.digit3 || key == LogicalKeyboardKey.numpad3)
+      }
+      if (key == LogicalKeyboardKey.digit3 ||
+          key == LogicalKeyboardKey.numpad3) {
         digit = '3';
-      if (key == LogicalKeyboardKey.digit4 || key == LogicalKeyboardKey.numpad4)
+      }
+      if (key == LogicalKeyboardKey.digit4 ||
+          key == LogicalKeyboardKey.numpad4) {
         digit = '4';
-      if (key == LogicalKeyboardKey.digit5 || key == LogicalKeyboardKey.numpad5)
+      }
+      if (key == LogicalKeyboardKey.digit5 ||
+          key == LogicalKeyboardKey.numpad5) {
         digit = '5';
-      if (key == LogicalKeyboardKey.digit6 || key == LogicalKeyboardKey.numpad6)
+      }
+      if (key == LogicalKeyboardKey.digit6 ||
+          key == LogicalKeyboardKey.numpad6) {
         digit = '6';
-      if (key == LogicalKeyboardKey.digit7 || key == LogicalKeyboardKey.numpad7)
+      }
+      if (key == LogicalKeyboardKey.digit7 ||
+          key == LogicalKeyboardKey.numpad7) {
         digit = '7';
-      if (key == LogicalKeyboardKey.digit8 || key == LogicalKeyboardKey.numpad8)
+      }
+      if (key == LogicalKeyboardKey.digit8 ||
+          key == LogicalKeyboardKey.numpad8) {
         digit = '8';
-      if (key == LogicalKeyboardKey.digit9 || key == LogicalKeyboardKey.numpad9)
+      }
+      if (key == LogicalKeyboardKey.digit9 ||
+          key == LogicalKeyboardKey.numpad9) {
         digit = '9';
+      }
       if (key == LogicalKeyboardKey.backspace) {
         setState(() {
           if (_rawAmount.isNotEmpty) {

--- a/lib/redeem_ecash.dart
+++ b/lib/redeem_ecash.dart
@@ -1,0 +1,128 @@
+import 'package:carbine/lib.dart';
+import 'package:carbine/main.dart';
+import 'package:carbine/success.dart';
+import 'package:flutter/material.dart';
+
+class EcashRedeemPrompt extends StatefulWidget {
+  final FederationSelector fed;
+  final String ecash;
+  final BigInt amount;
+
+  const EcashRedeemPrompt({
+    super.key,
+    required this.fed,
+    required this.ecash,
+    required this.amount,
+  });
+
+  @override
+  State<EcashRedeemPrompt> createState() => _EcashRedeemPromptState();
+}
+
+class _EcashRedeemPromptState extends State<EcashRedeemPrompt> {
+  bool _isLoading = false;
+
+  Future<void> _handleRedeem() async {
+    print("Handling redeem...");
+    setState(() {
+      _isLoading = true;
+    });
+
+    try {
+      final operationId = await reissueEcash(
+        federationId: widget.fed.federationId,
+        ecash: widget.ecash,
+      );
+      await awaitEcashReissue(
+        federationId: widget.fed.federationId,
+        operationId: operationId,
+      );
+
+      if (!mounted) return;
+
+      Navigator.push(
+        context,
+        MaterialPageRoute(
+          builder:
+              (context) => Success(
+                lightning: false,
+                received: true,
+                amountMsats: widget.amount,
+              ),
+        ),
+      );
+      await Future.delayed(const Duration(seconds: 4));
+      Navigator.of(
+        context,
+        rootNavigator: true,
+      ).popUntil((route) => route.isFirst);
+    } catch (_) {
+      // Could not reissue ecash
+      print("Could not reissue ecash");
+      Navigator.of(
+        context,
+        rootNavigator: true,
+      ).popUntil((route) => route.isFirst);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Text(
+          'Do you want to redeem the following ecash?',
+          style: theme.textTheme.titleLarge,
+          textAlign: TextAlign.center,
+        ),
+        const SizedBox(height: 16),
+        Text(
+          formatBalance(widget.amount, false),
+          textAlign: TextAlign.center,
+          style: theme.textTheme.displaySmall?.copyWith(
+            fontWeight: FontWeight.bold,
+            fontSize: 32,
+            color: Colors.greenAccent,
+            letterSpacing: 1.5,
+            shadows: [
+              Shadow(
+                blurRadius: 8,
+                color: Colors.greenAccent.withOpacity(0.4),
+                offset: const Offset(0, 0),
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(height: 32),
+        SizedBox(
+          width: double.infinity,
+          child: ElevatedButton(
+            onPressed: _isLoading ? null : _handleRedeem,
+            style: ElevatedButton.styleFrom(
+              backgroundColor: theme.colorScheme.primary,
+              foregroundColor: Colors.black,
+              padding: const EdgeInsets.symmetric(vertical: 16),
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(12),
+              ),
+            ),
+            child:
+                _isLoading
+                    ? const SizedBox(
+                      height: 20,
+                      width: 20,
+                      child: CircularProgressIndicator(
+                        strokeWidth: 2,
+                        valueColor: AlwaysStoppedAnimation<Color>(Colors.black),
+                      ),
+                    )
+                    : const Text('Confirm'),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/scan.dart
+++ b/lib/scan.dart
@@ -1,6 +1,7 @@
 import 'package:carbine/fed_preview.dart';
 import 'package:carbine/lib.dart';
 import 'package:carbine/pay_preview.dart';
+import 'package:carbine/redeem_ecash.dart';
 import 'package:carbine/theme.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -78,7 +79,29 @@ class _ScanQRPageState extends State<ScanQRPage> {
         );
       }
     } else {
-      print('Unknown text');
+      // TODO: Dont support direct scan yet, fix this later
+      if (widget.selectedFed != null) {
+        try {
+          print('Trying to parse ecash...');
+          final amountMsats = await parseEcash(
+            federationId: widget.selectedFed!.federationId,
+            ecash: text,
+          );
+          showCarbineModalBottomSheet(
+            context: context,
+            child: EcashRedeemPrompt(
+              fed: widget.selectedFed!,
+              ecash: text,
+              amount: amountMsats,
+            ),
+            heightFactor: 0.25,
+          );
+        } catch (_) {
+          print('Could not parse text as ecash');
+        }
+      } else {
+        print("Unknown Text");
+      }
     }
   }
 

--- a/lib/theme.dart
+++ b/lib/theme.dart
@@ -57,6 +57,7 @@ final ThemeData cypherpunkNinjaTheme = ThemeData(
 Future<T?> showCarbineModalBottomSheet<T>({
   required BuildContext context,
   required Widget child,
+  double? heightFactor,
 }) {
   return showModalBottomSheet<T>(
     context: context,
@@ -68,7 +69,7 @@ Future<T?> showCarbineModalBottomSheet<T>({
     builder: (context) {
       return SafeArea(
         child: FractionallySizedBox(
-          heightFactor: 0.80,
+          heightFactor: heightFactor ?? 0.8,
           child: Padding(
             padding: EdgeInsets.only(
               bottom: MediaQuery.of(context).viewInsets.bottom,

--- a/rust/carbine_fedimint/src/frb_generated.rs
+++ b/rust/carbine_fedimint/src/frb_generated.rs
@@ -39,7 +39,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.9.0";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -1555487335;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -2020551964;
 
 // Section: executor
 
@@ -2672,6 +2672,65 @@ fn wire__crate__list_federations_from_nostr_impl(
         },
     )
 }
+fn wire__crate__parse_ecash_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec, _, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "parse_ecash",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_federation_id = <RustOpaqueMoi<
+                flutter_rust_bridge::for_generated::RustAutoOpaqueInner<FederationId>,
+            >>::sse_decode(&mut deserializer);
+            let api_ecash = <String>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| async move {
+                transform_result_sse::<_, flutter_rust_bridge::for_generated::anyhow::Error>(
+                    (move || async move {
+                        let mut api_federation_id_guard = None;
+                        let decode_indices_ =
+                            flutter_rust_bridge::for_generated::lockable_compute_decode_order(
+                                vec![flutter_rust_bridge::for_generated::LockableOrderInfo::new(
+                                    &api_federation_id,
+                                    0,
+                                    false,
+                                )],
+                            );
+                        for i in decode_indices_ {
+                            match i {
+                                0 => {
+                                    api_federation_id_guard =
+                                        Some(api_federation_id.lockable_decode_async_ref().await)
+                                }
+                                _ => unreachable!(),
+                            }
+                        }
+                        let api_federation_id_guard = api_federation_id_guard.unwrap();
+                        let output_ok =
+                            crate::parse_ecash(&*api_federation_id_guard, api_ecash).await?;
+                        Ok(output_ok)
+                    })()
+                    .await,
+                )
+            }
+        },
+    )
+}
 fn wire__crate__payment_preview_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
@@ -3812,14 +3871,15 @@ fn pde_ffi_dispatcher_primary_impl(
         49 => wire__crate__init_multimint_impl(port, ptr, rust_vec_len, data_len),
         50 => wire__crate__join_federation_impl(port, ptr, rust_vec_len, data_len),
         51 => wire__crate__list_federations_from_nostr_impl(port, ptr, rust_vec_len, data_len),
-        52 => wire__crate__payment_preview_impl(port, ptr, rust_vec_len, data_len),
-        53 => wire__crate__receive_impl(port, ptr, rust_vec_len, data_len),
-        54 => wire__crate__reissue_ecash_impl(port, ptr, rust_vec_len, data_len),
-        55 => wire__crate__select_receive_gateway_impl(port, ptr, rust_vec_len, data_len),
-        56 => wire__crate__send_impl(port, ptr, rust_vec_len, data_len),
-        57 => wire__crate__send_ecash_impl(port, ptr, rust_vec_len, data_len),
-        58 => wire__crate__send_lnaddress_impl(port, ptr, rust_vec_len, data_len),
-        59 => wire__crate__transactions_impl(port, ptr, rust_vec_len, data_len),
+        52 => wire__crate__parse_ecash_impl(port, ptr, rust_vec_len, data_len),
+        53 => wire__crate__payment_preview_impl(port, ptr, rust_vec_len, data_len),
+        54 => wire__crate__receive_impl(port, ptr, rust_vec_len, data_len),
+        55 => wire__crate__reissue_ecash_impl(port, ptr, rust_vec_len, data_len),
+        56 => wire__crate__select_receive_gateway_impl(port, ptr, rust_vec_len, data_len),
+        57 => wire__crate__send_impl(port, ptr, rust_vec_len, data_len),
+        58 => wire__crate__send_ecash_impl(port, ptr, rust_vec_len, data_len),
+        59 => wire__crate__send_lnaddress_impl(port, ptr, rust_vec_len, data_len),
+        60 => wire__crate__transactions_impl(port, ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }


### PR DESCRIPTION
Adds a screen to redeem ecash from a string.

Commit was done before `dart format` commit hook, but I ran it manually so hopefully its still in line. If not, this will be the last PR where it has formatting issues