### PR TITLE
refactor: introduce toSats extension for BigInt

### DIFF
--- a/lib/ecash_send.dart
+++ b/lib/ecash_send.dart
@@ -18,7 +18,7 @@ class EcashSend extends StatefulWidget {
 class _EcashSendState extends State<EcashSend> {
   String? _ecash;
   bool _loading = true;
-  BigInt _ecashAmountMsats = BigInt.zero;
+  BigInt _ecashAmountSats = BigInt.zero;
   bool _reclaiming = false;
 
   double _progress = 0.0;
@@ -41,7 +41,7 @@ class _EcashSendState extends State<EcashSend> {
 
       setState(() {
         _ecash = ecash.$2;
-        _ecashAmountMsats = ecash.$3.toSats;
+        _ecashAmountSats = ecash.$3.toSats;
         _loading = false;
       });
     } catch (_) {
@@ -148,7 +148,7 @@ class _EcashSendState extends State<EcashSend> {
             ),
             const SizedBox(height: 8),
             Text(
-              "You’ve withdrawn ${_ecashAmountMsats.toString()} sats.\n"
+              "You’ve withdrawn ${_ecashAmountSats.toString()} sats.\n"
               "You must now send this ecash string to the recipient.",
               textAlign: TextAlign.center,
               style: Theme.of(context).textTheme.bodyMedium,

--- a/lib/ecash_send.dart
+++ b/lib/ecash_send.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'package:carbine/lib.dart';
+import 'package:carbine/utils.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:qr_flutter/qr_flutter.dart';
@@ -40,7 +41,7 @@ class _EcashSendState extends State<EcashSend> {
 
       setState(() {
         _ecash = ecash.$2;
-        _ecashAmountMsats = ecash.$3 ~/ BigInt.from(1000);
+        _ecashAmountMsats = ecash.$3.toSats;
         _loading = false;
       });
     } catch (_) {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,6 +6,7 @@ import 'package:carbine/setttings.dart';
 import 'package:carbine/sidebar.dart';
 import 'package:carbine/theme.dart';
 import 'package:carbine/welcome.dart';
+import 'package:carbine/utils.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:path_provider/path_provider.dart';
@@ -32,7 +33,7 @@ String formatBalance(BigInt? msats, bool showMsats) {
     formatted = formatted.replaceAll(',', ' ');
     return '$formatted msats';
   } else {
-    final sats = msats ~/ BigInt.from(1000);
+    final sats = msats.toSats;
     final formatter = NumberFormat('#,##0', 'en_US');
     var formatted = formatter.format(sats.toInt());
     return '$formatted sats';

--- a/lib/utils.dart
+++ b/lib/utils.dart
@@ -1,0 +1,3 @@
+extension MilliSats on BigInt {
+  BigInt get toSats => this ~/ BigInt.from(1000);
+}


### PR DESCRIPTION
@m1sterc001guy had a good suggestion that we should create a function for our msats -> sats conversions. Dart supports simple [extension methods](https://dart.dev/language/extension-methods), however we can also introduce a pure function if that's more clear.