### PR TITLE
fix: unify sats and msats formatting

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -35,6 +35,7 @@ String formatBalance(BigInt? msats, bool showMsats) {
     final sats = msats ~/ BigInt.from(1000);
     final formatter = NumberFormat('#,##0', 'en_US');
     var formatted = formatter.format(sats.toInt());
+    formatted = formatted.replaceAll(',', ' ');
     return '$formatted sats';
   }
 }


### PR DESCRIPTION
I'm a fan of the msats formatting that substitutes "," for spaces. This unifies the sats format on the dashboard to have the same formatting.

**Before**
![before](https://github.com/user-attachments/assets/33f36f03-8b34-4005-bb5a-b3ce474a45de)

**After**
![after](https://github.com/user-attachments/assets/9f5214b1-a096-4c63-aba1-439174cd06b0)
