### PR TITLE
fix: deadlock in recovery

### DIFF
--- a/lib/scan.dart
+++ b/lib/scan.dart
@@ -51,7 +51,7 @@ class _ScanQRPageState extends State<ScanQRPage> {
           bolt11: text,
         );
         if (widget.selectedFed!.network != preview.network) {
-          AppLogger.instance.w(
+          AppLogger.instance.warn(
             "Widget network: ${widget.selectedFed!.network} Preview: ${preview.network}",
           );
           ScaffoldMessenger.of(context).showSnackBar(

--- a/rust/carbine_fedimint/src/lib.rs
+++ b/rust/carbine_fedimint/src/lib.rs
@@ -431,8 +431,12 @@ pub async fn subscribe_deposits(
     sink: StreamSink<DepositEvent>,
     federation_id: FederationId,
 ) -> anyhow::Result<()> {
-    let multimint = get_multimint().await;
-    let mm = multimint.read().await;
+    let mm = {
+        let multimint = get_multimint().await;
+        let mm = multimint.read().await.clone();
+        mm
+    };
+
     mm.subscribe_deposits(federation_id, sink).await
 }
 


### PR DESCRIPTION
Found an interesting bug due to the new subscription mechanism. Because it returns a stream, it actually holds onto the `RwLock` that we have over `Multimint`. This will block any operation that requires a write lock on `Multimint`.

The fix is to remove the `RwLock` over `Multimint`. It is not necessary, we already have a `RwLock` over `clients` inside of `Multimint` and everything else should be clonable. I think this makes the code simpler.