### PR TITLE
feat: Async Lightning Receive

### DIFF
--- a/lib/frb_generated.dart
+++ b/lib/frb_generated.dart
@@ -65,7 +65,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.9.0';
 
   @override
-  int get rustContentHash => -381752716;
+  int get rustContentHash => 1337892317;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -76,24 +76,6 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
 }
 
 abstract class RustLibApi extends BaseApi {
-  DepositEventKind crateMultimintDepositEventAutoAccessorGetEventKind({
-    required DepositEvent that,
-  });
-
-  FederationId crateMultimintDepositEventAutoAccessorGetFederationId({
-    required DepositEvent that,
-  });
-
-  void crateMultimintDepositEventAutoAccessorSetEventKind({
-    required DepositEvent that,
-    required DepositEventKind eventKind,
-  });
-
-  void crateMultimintDepositEventAutoAccessorSetFederationId({
-    required DepositEvent that,
-    required FederationId federationId,
-  });
-
   ClientConfig crateDbFederationConfigAutoAccessorGetClientConfig({
     required FederationConfig that,
   });
@@ -175,6 +157,24 @@ abstract class RustLibApi extends BaseApi {
     String? network,
   });
 
+  MultimintEventKind crateMultimintMultimintEventAutoAccessorGetEventKind({
+    required MultimintEvent that,
+  });
+
+  FederationId crateMultimintMultimintEventAutoAccessorGetFederationId({
+    required MultimintEvent that,
+  });
+
+  void crateMultimintMultimintEventAutoAccessorSetEventKind({
+    required MultimintEvent that,
+    required MultimintEventKind eventKind,
+  });
+
+  void crateMultimintMultimintEventAutoAccessorSetFederationId({
+    required MultimintEvent that,
+    required FederationId federationId,
+  });
+
   Future<void> crateMultimintMultimintAckSeedPhrase({required Multimint that});
 
   Future<String> crateMultimintMultimintAllocateDepositAddress({
@@ -194,7 +194,8 @@ abstract class RustLibApi extends BaseApi {
     required OperationId operationId,
   });
 
-  Future<FinalReceiveOperationState> crateMultimintMultimintAwaitReceive({
+  Future<(FinalReceiveOperationState, BigInt)>
+  crateMultimintMultimintAwaitReceive({
     required Multimint that,
     required FederationId federationId,
     required OperationId operationId,
@@ -304,9 +305,13 @@ abstract class RustLibApi extends BaseApi {
     required BigInt amountMsats,
   });
 
-  Stream<DepositEvent> crateMultimintMultimintSubscribeDeposits({
+  Stream<DepositEventKind> crateMultimintMultimintSubscribeDeposits({
     required Multimint that,
     required FederationId federationId,
+  });
+
+  Stream<MultimintEvent> crateMultimintMultimintSubscribeMultimintEvents({
+    required Multimint that,
   });
 
   Future<List<Transaction>> crateMultimintMultimintTransactions({
@@ -421,7 +426,7 @@ abstract class RustLibApi extends BaseApi {
     required OperationId operationId,
   });
 
-  Future<FinalReceiveOperationState> crateAwaitReceive({
+  Future<(FinalReceiveOperationState, BigInt)> crateAwaitReceive({
     required FederationId federationId,
     required OperationId operationId,
   });
@@ -439,6 +444,10 @@ abstract class RustLibApi extends BaseApi {
   });
 
   Future<void> crateCreateNewMultimint({required String path});
+
+  Future<String> crateFederationIdToString({
+    required FederationId federationId,
+  });
 
   Future<List<(FederationSelector, bool)>> crateFederations();
 
@@ -524,9 +533,11 @@ abstract class RustLibApi extends BaseApi {
     required String relay,
   });
 
-  Stream<DepositEvent> crateSubscribeDeposits({
+  Stream<DepositEventKind> crateSubscribeDeposits({
     required FederationId federationId,
   });
+
+  Stream<MultimintEvent> crateSubscribeMultimintEvents();
 
   Future<List<Transaction>> crateTransactions({
     required FederationId federationId,
@@ -579,14 +590,6 @@ abstract class RustLibApi extends BaseApi {
   get rust_arc_decrement_strong_count_Database;
 
   CrossPlatformFinalizerArg get rust_arc_decrement_strong_count_DatabasePtr;
-
-  RustArcIncrementStrongCountFnType
-  get rust_arc_increment_strong_count_DepositEvent;
-
-  RustArcDecrementStrongCountFnType
-  get rust_arc_decrement_strong_count_DepositEvent;
-
-  CrossPlatformFinalizerArg get rust_arc_decrement_strong_count_DepositEventPtr;
 
   RustArcIncrementStrongCountFnType
   get rust_arc_increment_strong_count_FederationConfig;
@@ -649,6 +652,15 @@ abstract class RustLibApi extends BaseApi {
   CrossPlatformFinalizerArg get rust_arc_decrement_strong_count_MultimintPtr;
 
   RustArcIncrementStrongCountFnType
+  get rust_arc_increment_strong_count_MultimintEvent;
+
+  RustArcDecrementStrongCountFnType
+  get rust_arc_decrement_strong_count_MultimintEvent;
+
+  CrossPlatformFinalizerArg
+  get rust_arc_decrement_strong_count_MultimintEventPtr;
+
+  RustArcIncrementStrongCountFnType
   get rust_arc_increment_strong_count_NostrClient;
 
   RustArcDecrementStrongCountFnType
@@ -707,144 +719,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   });
 
   @override
-  DepositEventKind crateMultimintDepositEventAutoAccessorGetEventKind({
-    required DepositEvent that,
-  }) {
-    return handler.executeSync(
-      SyncTask(
-        callFfi: () {
-          final serializer = SseSerializer(generalizedFrbRustBinding);
-          sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDepositEvent(
-            that,
-            serializer,
-          );
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1)!;
-        },
-        codec: SseCodec(
-          decodeSuccessData: sse_decode_deposit_event_kind,
-          decodeErrorData: null,
-        ),
-        constMeta: kCrateMultimintDepositEventAutoAccessorGetEventKindConstMeta,
-        argValues: [that],
-        apiImpl: this,
-      ),
-    );
-  }
-
-  TaskConstMeta
-  get kCrateMultimintDepositEventAutoAccessorGetEventKindConstMeta =>
-      const TaskConstMeta(
-        debugName: "DepositEvent_auto_accessor_get_event_kind",
-        argNames: ["that"],
-      );
-
-  @override
-  FederationId crateMultimintDepositEventAutoAccessorGetFederationId({
-    required DepositEvent that,
-  }) {
-    return handler.executeSync(
-      SyncTask(
-        callFfi: () {
-          final serializer = SseSerializer(generalizedFrbRustBinding);
-          sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDepositEvent(
-            that,
-            serializer,
-          );
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 2)!;
-        },
-        codec: SseCodec(
-          decodeSuccessData:
-              sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerFederationId,
-          decodeErrorData: null,
-        ),
-        constMeta:
-            kCrateMultimintDepositEventAutoAccessorGetFederationIdConstMeta,
-        argValues: [that],
-        apiImpl: this,
-      ),
-    );
-  }
-
-  TaskConstMeta
-  get kCrateMultimintDepositEventAutoAccessorGetFederationIdConstMeta =>
-      const TaskConstMeta(
-        debugName: "DepositEvent_auto_accessor_get_federation_id",
-        argNames: ["that"],
-      );
-
-  @override
-  void crateMultimintDepositEventAutoAccessorSetEventKind({
-    required DepositEvent that,
-    required DepositEventKind eventKind,
-  }) {
-    return handler.executeSync(
-      SyncTask(
-        callFfi: () {
-          final serializer = SseSerializer(generalizedFrbRustBinding);
-          sse_encode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDepositEvent(
-            that,
-            serializer,
-          );
-          sse_encode_deposit_event_kind(eventKind, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 3)!;
-        },
-        codec: SseCodec(
-          decodeSuccessData: sse_decode_unit,
-          decodeErrorData: null,
-        ),
-        constMeta: kCrateMultimintDepositEventAutoAccessorSetEventKindConstMeta,
-        argValues: [that, eventKind],
-        apiImpl: this,
-      ),
-    );
-  }
-
-  TaskConstMeta
-  get kCrateMultimintDepositEventAutoAccessorSetEventKindConstMeta =>
-      const TaskConstMeta(
-        debugName: "DepositEvent_auto_accessor_set_event_kind",
-        argNames: ["that", "eventKind"],
-      );
-
-  @override
-  void crateMultimintDepositEventAutoAccessorSetFederationId({
-    required DepositEvent that,
-    required FederationId federationId,
-  }) {
-    return handler.executeSync(
-      SyncTask(
-        callFfi: () {
-          final serializer = SseSerializer(generalizedFrbRustBinding);
-          sse_encode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDepositEvent(
-            that,
-            serializer,
-          );
-          sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerFederationId(
-            federationId,
-            serializer,
-          );
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 4)!;
-        },
-        codec: SseCodec(
-          decodeSuccessData: sse_decode_unit,
-          decodeErrorData: null,
-        ),
-        constMeta:
-            kCrateMultimintDepositEventAutoAccessorSetFederationIdConstMeta,
-        argValues: [that, federationId],
-        apiImpl: this,
-      ),
-    );
-  }
-
-  TaskConstMeta
-  get kCrateMultimintDepositEventAutoAccessorSetFederationIdConstMeta =>
-      const TaskConstMeta(
-        debugName: "DepositEvent_auto_accessor_set_federation_id",
-        argNames: ["that", "federationId"],
-      );
-
-  @override
   ClientConfig crateDbFederationConfigAutoAccessorGetClientConfig({
     required FederationConfig that,
   }) {
@@ -856,7 +730,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             that,
             serializer,
           );
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 5)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1)!;
         },
         codec: SseCodec(
           decodeSuccessData:
@@ -889,7 +763,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             that,
             serializer,
           );
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 6)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 2)!;
         },
         codec: SseCodec(
           decodeSuccessData:
@@ -921,7 +795,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             that,
             serializer,
           );
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 7)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 3)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -954,7 +828,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             that,
             serializer,
           );
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 8)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 4)!;
         },
         codec: SseCodec(
           decodeSuccessData:
@@ -987,7 +861,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             that,
             serializer,
           );
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 9)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 5)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_opt_String,
@@ -1023,7 +897,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             clientConfig,
             serializer,
           );
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 10)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 6)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1060,7 +934,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             connector,
             serializer,
           );
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 11)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 7)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1093,7 +967,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             serializer,
           );
           sse_encode_String(federationName, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 12)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 8)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1131,7 +1005,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             inviteCode,
             serializer,
           );
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 13)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 9)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1165,7 +1039,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             serializer,
           );
           sse_encode_opt_String(network, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 14)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 10)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1196,7 +1070,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             that,
             serializer,
           );
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 15)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 11)!;
         },
         codec: SseCodec(
           decodeSuccessData:
@@ -1230,7 +1104,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             that,
             serializer,
           );
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 16)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 12)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -1263,7 +1137,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             that,
             serializer,
           );
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 17)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 13)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -1296,7 +1170,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             that,
             serializer,
           );
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 18)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 14)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_opt_String,
@@ -1334,7 +1208,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             federationId,
             serializer,
           );
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 19)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 15)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1369,7 +1243,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             serializer,
           );
           sse_encode_String(federationName, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 20)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 16)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1404,7 +1278,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             serializer,
           );
           sse_encode_String(inviteCode, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 21)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 17)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1439,7 +1313,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             serializer,
           );
           sse_encode_opt_String(network, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 22)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 18)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1458,6 +1332,146 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       const TaskConstMeta(
         debugName: "FederationSelector_auto_accessor_set_network",
         argNames: ["that", "network"],
+      );
+
+  @override
+  MultimintEventKind crateMultimintMultimintEventAutoAccessorGetEventKind({
+    required MultimintEvent that,
+  }) {
+    return handler.executeSync(
+      SyncTask(
+        callFfi: () {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMultimintEvent(
+            that,
+            serializer,
+          );
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 19)!;
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_multimint_event_kind,
+          decodeErrorData: null,
+        ),
+        constMeta:
+            kCrateMultimintMultimintEventAutoAccessorGetEventKindConstMeta,
+        argValues: [that],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta
+  get kCrateMultimintMultimintEventAutoAccessorGetEventKindConstMeta =>
+      const TaskConstMeta(
+        debugName: "MultimintEvent_auto_accessor_get_event_kind",
+        argNames: ["that"],
+      );
+
+  @override
+  FederationId crateMultimintMultimintEventAutoAccessorGetFederationId({
+    required MultimintEvent that,
+  }) {
+    return handler.executeSync(
+      SyncTask(
+        callFfi: () {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMultimintEvent(
+            that,
+            serializer,
+          );
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 20)!;
+        },
+        codec: SseCodec(
+          decodeSuccessData:
+              sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerFederationId,
+          decodeErrorData: null,
+        ),
+        constMeta:
+            kCrateMultimintMultimintEventAutoAccessorGetFederationIdConstMeta,
+        argValues: [that],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta
+  get kCrateMultimintMultimintEventAutoAccessorGetFederationIdConstMeta =>
+      const TaskConstMeta(
+        debugName: "MultimintEvent_auto_accessor_get_federation_id",
+        argNames: ["that"],
+      );
+
+  @override
+  void crateMultimintMultimintEventAutoAccessorSetEventKind({
+    required MultimintEvent that,
+    required MultimintEventKind eventKind,
+  }) {
+    return handler.executeSync(
+      SyncTask(
+        callFfi: () {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMultimintEvent(
+            that,
+            serializer,
+          );
+          sse_encode_multimint_event_kind(eventKind, serializer);
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 21)!;
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_unit,
+          decodeErrorData: null,
+        ),
+        constMeta:
+            kCrateMultimintMultimintEventAutoAccessorSetEventKindConstMeta,
+        argValues: [that, eventKind],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta
+  get kCrateMultimintMultimintEventAutoAccessorSetEventKindConstMeta =>
+      const TaskConstMeta(
+        debugName: "MultimintEvent_auto_accessor_set_event_kind",
+        argNames: ["that", "eventKind"],
+      );
+
+  @override
+  void crateMultimintMultimintEventAutoAccessorSetFederationId({
+    required MultimintEvent that,
+    required FederationId federationId,
+  }) {
+    return handler.executeSync(
+      SyncTask(
+        callFfi: () {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMultimintEvent(
+            that,
+            serializer,
+          );
+          sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerFederationId(
+            federationId,
+            serializer,
+          );
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 22)!;
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_unit,
+          decodeErrorData: null,
+        ),
+        constMeta:
+            kCrateMultimintMultimintEventAutoAccessorSetFederationIdConstMeta,
+        argValues: [that, federationId],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta
+  get kCrateMultimintMultimintEventAutoAccessorSetFederationIdConstMeta =>
+      const TaskConstMeta(
+        debugName: "MultimintEvent_auto_accessor_set_federation_id",
+        argNames: ["that", "federationId"],
       );
 
   @override
@@ -1630,7 +1644,8 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
-  Future<FinalReceiveOperationState> crateMultimintMultimintAwaitReceive({
+  Future<(FinalReceiveOperationState, BigInt)>
+  crateMultimintMultimintAwaitReceive({
     required Multimint that,
     required FederationId federationId,
     required OperationId operationId,
@@ -1660,7 +1675,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         },
         codec: SseCodec(
           decodeSuccessData:
-              sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerFinalReceiveOperationState,
+              sse_decode_record_auto_owned_rust_opaque_flutter_rust_bridgefor_generated_rust_auto_opaque_inner_final_receive_operation_state_u_64,
           decodeErrorData: sse_decode_AnyhowException,
         ),
         constMeta: kCrateMultimintMultimintAwaitReceiveConstMeta,
@@ -2464,11 +2479,11 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
-  Stream<DepositEvent> crateMultimintMultimintSubscribeDeposits({
+  Stream<DepositEventKind> crateMultimintMultimintSubscribeDeposits({
     required Multimint that,
     required FederationId federationId,
   }) {
-    final sink = RustStreamSink<DepositEvent>();
+    final sink = RustStreamSink<DepositEventKind>();
     unawaited(
       handler.executeNormal(
         NormalTask(
@@ -2482,10 +2497,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
               federationId,
               serializer,
             );
-            sse_encode_StreamSink_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDepositEvent_Sse(
-              sink,
-              serializer,
-            );
+            sse_encode_StreamSink_deposit_event_kind_Sse(sink, serializer);
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
@@ -2495,7 +2507,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           },
           codec: SseCodec(
             decodeSuccessData: sse_decode_unit,
-            decodeErrorData: sse_decode_AnyhowException,
+            decodeErrorData: null,
           ),
           constMeta: kCrateMultimintMultimintSubscribeDepositsConstMeta,
           argValues: [that, federationId, sink],
@@ -2510,6 +2522,50 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       const TaskConstMeta(
         debugName: "Multimint_subscribe_deposits",
         argNames: ["that", "federationId", "sink"],
+      );
+
+  @override
+  Stream<MultimintEvent> crateMultimintMultimintSubscribeMultimintEvents({
+    required Multimint that,
+  }) {
+    final sink = RustStreamSink<MultimintEvent>();
+    unawaited(
+      handler.executeNormal(
+        NormalTask(
+          callFfi: (port_) {
+            final serializer = SseSerializer(generalizedFrbRustBinding);
+            sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMultimint(
+              that,
+              serializer,
+            );
+            sse_encode_StreamSink_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMultimintEvent_Sse(
+              sink,
+              serializer,
+            );
+            pdeCallFfi(
+              generalizedFrbRustBinding,
+              serializer,
+              funcId: 47,
+              port: port_,
+            );
+          },
+          codec: SseCodec(
+            decodeSuccessData: sse_decode_unit,
+            decodeErrorData: null,
+          ),
+          constMeta: kCrateMultimintMultimintSubscribeMultimintEventsConstMeta,
+          argValues: [that, sink],
+          apiImpl: this,
+        ),
+      ),
+    );
+    return sink.stream;
+  }
+
+  TaskConstMeta get kCrateMultimintMultimintSubscribeMultimintEventsConstMeta =>
+      const TaskConstMeta(
+        debugName: "Multimint_subscribe_multimint_events",
+        argNames: ["that", "sink"],
       );
 
   @override
@@ -2538,7 +2594,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 47,
+            funcId: 48,
             port: port_,
           );
         },
@@ -2582,7 +2638,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 48,
+            funcId: 49,
             port: port_,
           );
         },
@@ -2618,7 +2674,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 49,
+            funcId: 50,
             port: port_,
           );
         },
@@ -2657,7 +2713,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 50,
+            funcId: 51,
             port: port_,
           );
         },
@@ -2694,7 +2750,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 51,
+            funcId: 52,
             port: port_,
           );
         },
@@ -2728,7 +2784,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 52,
+            funcId: 53,
             port: port_,
           );
         },
@@ -2769,7 +2825,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 53,
+            funcId: 54,
             port: port_,
           );
         },
@@ -2802,7 +2858,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             that,
             serializer,
           );
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 54)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 55)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_opt_String,
@@ -2833,7 +2889,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             that,
             serializer,
           );
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 55)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 56)!;
         },
         codec: SseCodec(
           decodeSuccessData:
@@ -2867,7 +2923,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             that,
             serializer,
           );
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 56)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 57)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -2900,7 +2956,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             that,
             serializer,
           );
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 57)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 58)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_list_String,
@@ -2933,7 +2989,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             that,
             serializer,
           );
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 58)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 59)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_list_String,
@@ -2965,7 +3021,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             that,
             serializer,
           );
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 59)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 60)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -2997,7 +3053,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             that,
             serializer,
           );
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 60)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 61)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_opt_String,
@@ -3031,7 +3087,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             serializer,
           );
           sse_encode_opt_String(about, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 61)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 62)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -3067,7 +3123,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             federationId,
             serializer,
           );
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 62)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 63)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -3102,7 +3158,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             serializer,
           );
           sse_encode_String(federationName, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 63)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 64)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -3137,7 +3193,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             serializer,
           );
           sse_encode_list_String(inviteCodes, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 64)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 65)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -3172,7 +3228,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             serializer,
           );
           sse_encode_list_String(modules, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 65)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 66)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -3206,7 +3262,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             serializer,
           );
           sse_encode_String(network, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 66)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 67)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -3240,7 +3296,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             serializer,
           );
           sse_encode_opt_String(picture, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 67)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 68)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -3269,7 +3325,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 68,
+            funcId: 69,
             port: port_,
           );
         },
@@ -3302,7 +3358,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 69,
+            funcId: 70,
             port: port_,
           );
         },
@@ -3343,7 +3399,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 70,
+            funcId: 71,
             port: port_,
           );
         },
@@ -3384,7 +3440,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 71,
+            funcId: 72,
             port: port_,
           );
         },
@@ -3406,7 +3462,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   );
 
   @override
-  Future<FinalReceiveOperationState> crateAwaitReceive({
+  Future<(FinalReceiveOperationState, BigInt)> crateAwaitReceive({
     required FederationId federationId,
     required OperationId operationId,
   }) {
@@ -3425,13 +3481,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 72,
+            funcId: 73,
             port: port_,
           );
         },
         codec: SseCodec(
           decodeSuccessData:
-              sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerFinalReceiveOperationState,
+              sse_decode_record_auto_owned_rust_opaque_flutter_rust_bridgefor_generated_rust_auto_opaque_inner_final_receive_operation_state_u_64,
           decodeErrorData: sse_decode_AnyhowException,
         ),
         constMeta: kCrateAwaitReceiveConstMeta,
@@ -3466,7 +3522,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 73,
+            funcId: 74,
             port: port_,
           );
         },
@@ -3500,7 +3556,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 74,
+            funcId: 75,
             port: port_,
           );
         },
@@ -3532,7 +3588,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 75,
+            funcId: 76,
             port: port_,
           );
         },
@@ -3563,7 +3619,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 76,
+            funcId: 77,
             port: port_,
           );
         },
@@ -3584,6 +3640,41 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   );
 
   @override
+  Future<String> crateFederationIdToString({
+    required FederationId federationId,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerFederationId(
+            federationId,
+            serializer,
+          );
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 78,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_String,
+          decodeErrorData: null,
+        ),
+        constMeta: kCrateFederationIdToStringConstMeta,
+        argValues: [federationId],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateFederationIdToStringConstMeta => const TaskConstMeta(
+    debugName: "federation_id_to_string",
+    argNames: ["federationId"],
+  );
+
+  @override
   Future<List<(FederationSelector, bool)>> crateFederations() {
     return handler.executeNormal(
       NormalTask(
@@ -3592,7 +3683,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 77,
+            funcId: 79,
             port: port_,
           );
         },
@@ -3623,7 +3714,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 78,
+            funcId: 80,
             port: port_,
           );
         },
@@ -3653,7 +3744,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 79,
+            funcId: 81,
             port: port_,
           );
         },
@@ -3681,7 +3772,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 80,
+            funcId: 82,
             port: port_,
           );
         },
@@ -3709,7 +3800,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 81,
+            funcId: 83,
             port: port_,
           );
         },
@@ -3736,7 +3827,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 82,
+            funcId: 84,
             port: port_,
           );
         },
@@ -3768,7 +3859,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 83,
+            funcId: 85,
             port: port_,
           );
         },
@@ -3801,7 +3892,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 84,
+            funcId: 86,
             port: port_,
           );
         },
@@ -3833,7 +3924,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 85,
+            funcId: 87,
             port: port_,
           );
         },
@@ -3868,7 +3959,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 86,
+            funcId: 88,
             port: port_,
           );
         },
@@ -3905,7 +3996,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 87,
+            funcId: 89,
             port: port_,
           );
         },
@@ -3942,7 +4033,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 88,
+            funcId: 90,
             port: port_,
           );
         },
@@ -3985,7 +4076,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 89,
+            funcId: 91,
             port: port_,
           );
         },
@@ -4031,7 +4122,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 90,
+            funcId: 92,
             port: port_,
           );
         },
@@ -4066,7 +4157,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 91,
+            funcId: 93,
             port: port_,
           );
         },
@@ -4104,7 +4195,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 92,
+            funcId: 94,
             port: port_,
           );
         },
@@ -4145,7 +4236,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 93,
+            funcId: 95,
             port: port_,
           );
         },
@@ -4183,7 +4274,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 94,
+            funcId: 96,
             port: port_,
           );
         },
@@ -4223,7 +4314,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 95,
+            funcId: 97,
             port: port_,
           );
         },
@@ -4261,7 +4352,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 96,
+            funcId: 98,
             port: port_,
           );
         },
@@ -4282,19 +4373,16 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   );
 
   @override
-  Stream<DepositEvent> crateSubscribeDeposits({
+  Stream<DepositEventKind> crateSubscribeDeposits({
     required FederationId federationId,
   }) {
-    final sink = RustStreamSink<DepositEvent>();
+    final sink = RustStreamSink<DepositEventKind>();
     unawaited(
       handler.executeNormal(
         NormalTask(
           callFfi: (port_) {
             final serializer = SseSerializer(generalizedFrbRustBinding);
-            sse_encode_StreamSink_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDepositEvent_Sse(
-              sink,
-              serializer,
-            );
+            sse_encode_StreamSink_deposit_event_kind_Sse(sink, serializer);
             sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerFederationId(
               federationId,
               serializer,
@@ -4302,13 +4390,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 97,
+              funcId: 99,
               port: port_,
             );
           },
           codec: SseCodec(
             decodeSuccessData: sse_decode_unit,
-            decodeErrorData: sse_decode_AnyhowException,
+            decodeErrorData: null,
           ),
           constMeta: kCrateSubscribeDepositsConstMeta,
           argValues: [sink, federationId],
@@ -4323,6 +4411,44 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     debugName: "subscribe_deposits",
     argNames: ["sink", "federationId"],
   );
+
+  @override
+  Stream<MultimintEvent> crateSubscribeMultimintEvents() {
+    final sink = RustStreamSink<MultimintEvent>();
+    unawaited(
+      handler.executeNormal(
+        NormalTask(
+          callFfi: (port_) {
+            final serializer = SseSerializer(generalizedFrbRustBinding);
+            sse_encode_StreamSink_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMultimintEvent_Sse(
+              sink,
+              serializer,
+            );
+            pdeCallFfi(
+              generalizedFrbRustBinding,
+              serializer,
+              funcId: 100,
+              port: port_,
+            );
+          },
+          codec: SseCodec(
+            decodeSuccessData: sse_decode_unit,
+            decodeErrorData: null,
+          ),
+          constMeta: kCrateSubscribeMultimintEventsConstMeta,
+          argValues: [sink],
+          apiImpl: this,
+        ),
+      ),
+    );
+    return sink.stream;
+  }
+
+  TaskConstMeta get kCrateSubscribeMultimintEventsConstMeta =>
+      const TaskConstMeta(
+        debugName: "subscribe_multimint_events",
+        argNames: ["sink"],
+      );
 
   @override
   Future<List<Transaction>> crateTransactions({
@@ -4345,7 +4471,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 98,
+            funcId: 101,
             port: port_,
           );
         },
@@ -4377,7 +4503,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 99,
+            funcId: 102,
             port: port_,
           );
         },
@@ -4408,7 +4534,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 100,
+            funcId: 103,
             port: port_,
           );
         },
@@ -4435,7 +4561,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 101,
+            funcId: 104,
             port: port_,
           );
         },
@@ -4494,14 +4620,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       wire.rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDatabase;
 
   RustArcIncrementStrongCountFnType
-  get rust_arc_increment_strong_count_DepositEvent =>
-      wire.rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDepositEvent;
-
-  RustArcDecrementStrongCountFnType
-  get rust_arc_decrement_strong_count_DepositEvent =>
-      wire.rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDepositEvent;
-
-  RustArcIncrementStrongCountFnType
   get rust_arc_increment_strong_count_FederationConfig =>
       wire.rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerFederationConfig;
 
@@ -4556,6 +4674,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   RustArcDecrementStrongCountFnType
   get rust_arc_decrement_strong_count_Multimint =>
       wire.rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMultimint;
+
+  RustArcIncrementStrongCountFnType
+  get rust_arc_increment_strong_count_MultimintEvent =>
+      wire.rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMultimintEvent;
+
+  RustArcDecrementStrongCountFnType
+  get rust_arc_decrement_strong_count_MultimintEvent =>
+      wire.rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMultimintEvent;
 
   RustArcIncrementStrongCountFnType
   get rust_arc_increment_strong_count_NostrClient =>
@@ -4657,15 +4783,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
-  DepositEvent
-  dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDepositEvent(
-    dynamic raw,
-  ) {
-    // Codec=Dco (DartCObject based), see doc to use other codecs
-    return DepositEventImpl.frbInternalDcoDecode(raw as List<dynamic>);
-  }
-
-  @protected
   FederationConfig
   dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerFederationConfig(
     dynamic raw,
@@ -4733,6 +4850,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  MultimintEvent
+  dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMultimintEvent(
+    dynamic raw,
+  ) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return MultimintEventImpl.frbInternalDcoDecode(raw as List<dynamic>);
+  }
+
+  @protected
   NostrClient
   dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNostrClient(
     dynamic raw,
@@ -4789,15 +4915,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
-  DepositEvent
-  dco_decode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDepositEvent(
-    dynamic raw,
-  ) {
-    // Codec=Dco (DartCObject based), see doc to use other codecs
-    return DepositEventImpl.frbInternalDcoDecode(raw as List<dynamic>);
-  }
-
-  @protected
   FederationConfig
   dco_decode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerFederationConfig(
     dynamic raw,
@@ -4825,6 +4942,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  MultimintEvent
+  dco_decode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMultimintEvent(
+    dynamic raw,
+  ) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return MultimintEventImpl.frbInternalDcoDecode(raw as List<dynamic>);
+  }
+
+  @protected
   NostrClient
   dco_decode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNostrClient(
     dynamic raw,
@@ -4840,15 +4966,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return PublicFederationImpl.frbInternalDcoDecode(raw as List<dynamic>);
-  }
-
-  @protected
-  DepositEvent
-  dco_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDepositEvent(
-    dynamic raw,
-  ) {
-    // Codec=Dco (DartCObject based), see doc to use other codecs
-    return DepositEventImpl.frbInternalDcoDecode(raw as List<dynamic>);
   }
 
   @protected
@@ -4885,6 +5002,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return MultimintImpl.frbInternalDcoDecode(raw as List<dynamic>);
+  }
+
+  @protected
+  MultimintEvent
+  dco_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMultimintEvent(
+    dynamic raw,
+  ) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return MultimintEventImpl.frbInternalDcoDecode(raw as List<dynamic>);
   }
 
   @protected
@@ -4948,15 +5074,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return DatabaseImpl.frbInternalDcoDecode(raw as List<dynamic>);
-  }
-
-  @protected
-  DepositEvent
-  dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDepositEvent(
-    dynamic raw,
-  ) {
-    // Codec=Dco (DartCObject based), see doc to use other codecs
-    return DepositEventImpl.frbInternalDcoDecode(raw as List<dynamic>);
   }
 
   @protected
@@ -5027,6 +5144,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  MultimintEvent
+  dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMultimintEvent(
+    dynamic raw,
+  ) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return MultimintEventImpl.frbInternalDcoDecode(raw as List<dynamic>);
+  }
+
+  @protected
   NostrClient
   dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNostrClient(
     dynamic raw,
@@ -5083,8 +5209,16 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
-  RustStreamSink<DepositEvent>
-  dco_decode_StreamSink_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDepositEvent_Sse(
+  RustStreamSink<MultimintEvent>
+  dco_decode_StreamSink_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMultimintEvent_Sse(
+    dynamic raw,
+  ) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    throw UnimplementedError();
+  }
+
+  @protected
+  RustStreamSink<DepositEventKind> dco_decode_StreamSink_deposit_event_kind_Sse(
     dynamic raw,
   ) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
@@ -5133,6 +5267,24 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ConfirmedEvent dco_decode_box_autoadd_confirmed_event(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return dco_decode_confirmed_event(raw);
+  }
+
+  @protected
+  DepositEventKind dco_decode_box_autoadd_deposit_event_kind(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return dco_decode_deposit_event_kind(raw);
+  }
+
+  @protected
+  InvoicePaidEvent dco_decode_box_autoadd_invoice_paid_event(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return dco_decode_invoice_paid_event(raw);
+  }
+
+  @protected
+  LightningEventKind dco_decode_box_autoadd_lightning_event_kind(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return dco_decode_lightning_event_kind(raw);
   }
 
   @protected
@@ -5228,6 +5380,28 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  InvoicePaidEvent dco_decode_invoice_paid_event(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 1)
+      throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
+    return InvoicePaidEvent(amountMsats: dco_decode_u_64(arr[0]));
+  }
+
+  @protected
+  LightningEventKind dco_decode_lightning_event_kind(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    switch (raw[0]) {
+      case 0:
+        return LightningEventKind_InvoicePaid(
+          dco_decode_box_autoadd_invoice_paid_event(raw[1]),
+        );
+      default:
+        throw Exception("unreachable");
+    }
+  }
+
+  @protected
   List<PublicFederation>
   dco_decode_list_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPublicFederation(
     dynamic raw,
@@ -5313,6 +5487,23 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       case 2:
         return MultimintCreation_NewFromMnemonic(
           words: dco_decode_list_String(raw[1]),
+        );
+      default:
+        throw Exception("unreachable");
+    }
+  }
+
+  @protected
+  MultimintEventKind dco_decode_multimint_event_kind(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    switch (raw[0]) {
+      case 0:
+        return MultimintEventKind_Deposit(
+          dco_decode_box_autoadd_deposit_event_kind(raw[1]),
+        );
+      case 1:
+        return MultimintEventKind_Lightning(
+          dco_decode_box_autoadd_lightning_event_kind(raw[1]),
         );
       default:
         throw Exception("unreachable");
@@ -5420,6 +5611,24 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         arr[0],
       ),
       dco_decode_nwc_connection_info(arr[1]),
+    );
+  }
+
+  @protected
+  (FinalReceiveOperationState, BigInt)
+  dco_decode_record_auto_owned_rust_opaque_flutter_rust_bridgefor_generated_rust_auto_opaque_inner_final_receive_operation_state_u_64(
+    dynamic raw,
+  ) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 2) {
+      throw Exception('Expected 2 elements, got ${arr.length}');
+    }
+    return (
+      dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerFinalReceiveOperationState(
+        arr[0],
+      ),
+      dco_decode_u_64(arr[1]),
     );
   }
 
@@ -5630,18 +5839,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
-  DepositEvent
-  sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDepositEvent(
-    SseDeserializer deserializer,
-  ) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    return DepositEventImpl.frbInternalSseDecode(
-      sse_decode_usize(deserializer),
-      sse_decode_i_32(deserializer),
-    );
-  }
-
-  @protected
   FederationConfig
   sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerFederationConfig(
     SseDeserializer deserializer,
@@ -5726,6 +5923,18 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  MultimintEvent
+  sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMultimintEvent(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    return MultimintEventImpl.frbInternalSseDecode(
+      sse_decode_usize(deserializer),
+      sse_decode_i_32(deserializer),
+    );
+  }
+
+  @protected
   NostrClient
   sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNostrClient(
     SseDeserializer deserializer,
@@ -5798,18 +6007,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
-  DepositEvent
-  sse_decode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDepositEvent(
-    SseDeserializer deserializer,
-  ) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    return DepositEventImpl.frbInternalSseDecode(
-      sse_decode_usize(deserializer),
-      sse_decode_i_32(deserializer),
-    );
-  }
-
-  @protected
   FederationConfig
   sse_decode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerFederationConfig(
     SseDeserializer deserializer,
@@ -5846,6 +6043,18 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  MultimintEvent
+  sse_decode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMultimintEvent(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    return MultimintEventImpl.frbInternalSseDecode(
+      sse_decode_usize(deserializer),
+      sse_decode_i_32(deserializer),
+    );
+  }
+
+  @protected
   NostrClient
   sse_decode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNostrClient(
     SseDeserializer deserializer,
@@ -5864,18 +6073,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     return PublicFederationImpl.frbInternalSseDecode(
-      sse_decode_usize(deserializer),
-      sse_decode_i_32(deserializer),
-    );
-  }
-
-  @protected
-  DepositEvent
-  sse_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDepositEvent(
-    SseDeserializer deserializer,
-  ) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    return DepositEventImpl.frbInternalSseDecode(
       sse_decode_usize(deserializer),
       sse_decode_i_32(deserializer),
     );
@@ -5924,6 +6121,18 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     return MultimintImpl.frbInternalSseDecode(
+      sse_decode_usize(deserializer),
+      sse_decode_i_32(deserializer),
+    );
+  }
+
+  @protected
+  MultimintEvent
+  sse_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMultimintEvent(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    return MultimintEventImpl.frbInternalSseDecode(
       sse_decode_usize(deserializer),
       sse_decode_i_32(deserializer),
     );
@@ -6014,18 +6223,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
-  DepositEvent
-  sse_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDepositEvent(
-    SseDeserializer deserializer,
-  ) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    return DepositEventImpl.frbInternalSseDecode(
-      sse_decode_usize(deserializer),
-      sse_decode_i_32(deserializer),
-    );
-  }
-
-  @protected
   FederationConfig
   sse_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerFederationConfig(
     SseDeserializer deserializer,
@@ -6110,6 +6307,18 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  MultimintEvent
+  sse_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMultimintEvent(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    return MultimintEventImpl.frbInternalSseDecode(
+      sse_decode_usize(deserializer),
+      sse_decode_i_32(deserializer),
+    );
+  }
+
+  @protected
   NostrClient
   sse_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNostrClient(
     SseDeserializer deserializer,
@@ -6182,8 +6391,16 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
-  RustStreamSink<DepositEvent>
-  sse_decode_StreamSink_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDepositEvent_Sse(
+  RustStreamSink<MultimintEvent>
+  sse_decode_StreamSink_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMultimintEvent_Sse(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    throw UnimplementedError('Unreachable ()');
+  }
+
+  @protected
+  RustStreamSink<DepositEventKind> sse_decode_StreamSink_deposit_event_kind_Sse(
     SseDeserializer deserializer,
   ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
@@ -6242,6 +6459,30 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     return (sse_decode_confirmed_event(deserializer));
+  }
+
+  @protected
+  DepositEventKind sse_decode_box_autoadd_deposit_event_kind(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    return (sse_decode_deposit_event_kind(deserializer));
+  }
+
+  @protected
+  InvoicePaidEvent sse_decode_box_autoadd_invoice_paid_event(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    return (sse_decode_invoice_paid_event(deserializer));
+  }
+
+  @protected
+  LightningEventKind sse_decode_box_autoadd_lightning_event_kind(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    return (sse_decode_lightning_event_kind(deserializer));
   }
 
   @protected
@@ -6326,6 +6567,31 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     var var_name = sse_decode_String(deserializer);
     var var_version = sse_decode_opt_String(deserializer);
     return Guardian(name: var_name, version: var_version);
+  }
+
+  @protected
+  InvoicePaidEvent sse_decode_invoice_paid_event(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_amountMsats = sse_decode_u_64(deserializer);
+    return InvoicePaidEvent(amountMsats: var_amountMsats);
+  }
+
+  @protected
+  LightningEventKind sse_decode_lightning_event_kind(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    var tag_ = sse_decode_i_32(deserializer);
+    switch (tag_) {
+      case 0:
+        var var_field0 = sse_decode_box_autoadd_invoice_paid_event(
+          deserializer,
+        );
+        return LightningEventKind_InvoicePaid(var_field0);
+      default:
+        throw UnimplementedError('');
+    }
   }
 
   @protected
@@ -6457,6 +6723,29 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  MultimintEventKind sse_decode_multimint_event_kind(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    var tag_ = sse_decode_i_32(deserializer);
+    switch (tag_) {
+      case 0:
+        var var_field0 = sse_decode_box_autoadd_deposit_event_kind(
+          deserializer,
+        );
+        return MultimintEventKind_Deposit(var_field0);
+      case 1:
+        var var_field0 = sse_decode_box_autoadd_lightning_event_kind(
+          deserializer,
+        );
+        return MultimintEventKind_Lightning(var_field0);
+      default:
+        throw UnimplementedError('');
+    }
+  }
+
+  @protected
   NWCConnectionInfo sse_decode_nwc_connection_info(
     SseDeserializer deserializer,
   ) {
@@ -6567,6 +6856,20 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           deserializer,
         );
     var var_field1 = sse_decode_nwc_connection_info(deserializer);
+    return (var_field0, var_field1);
+  }
+
+  @protected
+  (FinalReceiveOperationState, BigInt)
+  sse_decode_record_auto_owned_rust_opaque_flutter_rust_bridgefor_generated_rust_auto_opaque_inner_final_receive_operation_state_u_64(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_field0 =
+        sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerFinalReceiveOperationState(
+          deserializer,
+        );
+    var var_field1 = sse_decode_u_64(deserializer);
     return (var_field0, var_field1);
   }
 
@@ -6771,19 +7074,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   @protected
   void
-  sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDepositEvent(
-    DepositEvent self,
-    SseSerializer serializer,
-  ) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    sse_encode_usize(
-      (self as DepositEventImpl).frbInternalSseEncode(move: true),
-      serializer,
-    );
-  }
-
-  @protected
-  void
   sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerFederationConfig(
     FederationConfig self,
     SseSerializer serializer,
@@ -6875,6 +7165,19 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   @protected
   void
+  sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMultimintEvent(
+    MultimintEvent self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_usize(
+      (self as MultimintEventImpl).frbInternalSseEncode(move: true),
+      serializer,
+    );
+  }
+
+  @protected
+  void
   sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNostrClient(
     NostrClient self,
     SseSerializer serializer,
@@ -6953,19 +7256,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   @protected
   void
-  sse_encode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDepositEvent(
-    DepositEvent self,
-    SseSerializer serializer,
-  ) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    sse_encode_usize(
-      (self as DepositEventImpl).frbInternalSseEncode(move: false),
-      serializer,
-    );
-  }
-
-  @protected
-  void
   sse_encode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerFederationConfig(
     FederationConfig self,
     SseSerializer serializer,
@@ -7005,6 +7295,19 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   @protected
   void
+  sse_encode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMultimintEvent(
+    MultimintEvent self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_usize(
+      (self as MultimintEventImpl).frbInternalSseEncode(move: false),
+      serializer,
+    );
+  }
+
+  @protected
+  void
   sse_encode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNostrClient(
     NostrClient self,
     SseSerializer serializer,
@@ -7025,19 +7328,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_usize(
       (self as PublicFederationImpl).frbInternalSseEncode(move: false),
-      serializer,
-    );
-  }
-
-  @protected
-  void
-  sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDepositEvent(
-    DepositEvent self,
-    SseSerializer serializer,
-  ) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    sse_encode_usize(
-      (self as DepositEventImpl).frbInternalSseEncode(move: false),
       serializer,
     );
   }
@@ -7090,6 +7380,19 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_usize(
       (self as MultimintImpl).frbInternalSseEncode(move: false),
+      serializer,
+    );
+  }
+
+  @protected
+  void
+  sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMultimintEvent(
+    MultimintEvent self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_usize(
+      (self as MultimintEventImpl).frbInternalSseEncode(move: false),
       serializer,
     );
   }
@@ -7187,19 +7490,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   @protected
   void
-  sse_encode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDepositEvent(
-    DepositEvent self,
-    SseSerializer serializer,
-  ) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    sse_encode_usize(
-      (self as DepositEventImpl).frbInternalSseEncode(move: null),
-      serializer,
-    );
-  }
-
-  @protected
-  void
   sse_encode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerFederationConfig(
     FederationConfig self,
     SseSerializer serializer,
@@ -7291,6 +7581,19 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   @protected
   void
+  sse_encode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMultimintEvent(
+    MultimintEvent self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_usize(
+      (self as MultimintEventImpl).frbInternalSseEncode(move: null),
+      serializer,
+    );
+  }
+
+  @protected
+  void
   sse_encode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNostrClient(
     NostrClient self,
     SseSerializer serializer,
@@ -7369,8 +7672,8 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   @protected
   void
-  sse_encode_StreamSink_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDepositEvent_Sse(
-    RustStreamSink<DepositEvent> self,
+  sse_encode_StreamSink_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMultimintEvent_Sse(
+    RustStreamSink<MultimintEvent> self,
     SseSerializer serializer,
   ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
@@ -7378,7 +7681,24 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       self.setupAndSerialize(
         codec: SseCodec(
           decodeSuccessData:
-              sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDepositEvent,
+              sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMultimintEvent,
+          decodeErrorData: sse_decode_AnyhowException,
+        ),
+      ),
+      serializer,
+    );
+  }
+
+  @protected
+  void sse_encode_StreamSink_deposit_event_kind_Sse(
+    RustStreamSink<DepositEventKind> self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_String(
+      self.setupAndSerialize(
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_deposit_event_kind,
           decodeErrorData: sse_decode_AnyhowException,
         ),
       ),
@@ -7435,6 +7755,33 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_confirmed_event(self, serializer);
+  }
+
+  @protected
+  void sse_encode_box_autoadd_deposit_event_kind(
+    DepositEventKind self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_deposit_event_kind(self, serializer);
+  }
+
+  @protected
+  void sse_encode_box_autoadd_invoice_paid_event(
+    InvoicePaidEvent self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_invoice_paid_event(self, serializer);
+  }
+
+  @protected
+  void sse_encode_box_autoadd_lightning_event_kind(
+    LightningEventKind self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_lightning_event_kind(self, serializer);
   }
 
   @protected
@@ -7516,6 +7863,28 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_String(self.name, serializer);
     sse_encode_opt_String(self.version, serializer);
+  }
+
+  @protected
+  void sse_encode_invoice_paid_event(
+    InvoicePaidEvent self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_u_64(self.amountMsats, serializer);
+  }
+
+  @protected
+  void sse_encode_lightning_event_kind(
+    LightningEventKind self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    switch (self) {
+      case LightningEventKind_InvoicePaid(field0: final field0):
+        sse_encode_i_32(0, serializer);
+        sse_encode_box_autoadd_invoice_paid_event(field0, serializer);
+    }
   }
 
   @protected
@@ -7631,6 +8000,22 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  void sse_encode_multimint_event_kind(
+    MultimintEventKind self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    switch (self) {
+      case MultimintEventKind_Deposit(field0: final field0):
+        sse_encode_i_32(0, serializer);
+        sse_encode_box_autoadd_deposit_event_kind(field0, serializer);
+      case MultimintEventKind_Lightning(field0: final field0):
+        sse_encode_i_32(1, serializer);
+        sse_encode_box_autoadd_lightning_event_kind(field0, serializer);
+    }
+  }
+
+  @protected
   void sse_encode_nwc_connection_info(
     NWCConnectionInfo self,
     SseSerializer serializer,
@@ -7732,6 +8117,20 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       serializer,
     );
     sse_encode_nwc_connection_info(self.$2, serializer);
+  }
+
+  @protected
+  void
+  sse_encode_record_auto_owned_rust_opaque_flutter_rust_bridgefor_generated_rust_auto_opaque_inner_final_receive_operation_state_u_64(
+    (FinalReceiveOperationState, BigInt) self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerFinalReceiveOperationState(
+      self.$1,
+      serializer,
+    );
+    sse_encode_u_64(self.$2, serializer);
   }
 
   @protected
@@ -7953,44 +8352,6 @@ class DatabaseImpl extends RustOpaque implements Database {
     rustArcDecrementStrongCountPtr:
         RustLib.instance.api.rust_arc_decrement_strong_count_DatabasePtr,
   );
-}
-
-@sealed
-class DepositEventImpl extends RustOpaque implements DepositEvent {
-  // Not to be used by end users
-  DepositEventImpl.frbInternalDcoDecode(List<dynamic> wire)
-    : super.frbInternalDcoDecode(wire, _kStaticData);
-
-  // Not to be used by end users
-  DepositEventImpl.frbInternalSseDecode(BigInt ptr, int externalSizeOnNative)
-    : super.frbInternalSseDecode(ptr, externalSizeOnNative, _kStaticData);
-
-  static final _kStaticData = RustArcStaticData(
-    rustArcIncrementStrongCount:
-        RustLib.instance.api.rust_arc_increment_strong_count_DepositEvent,
-    rustArcDecrementStrongCount:
-        RustLib.instance.api.rust_arc_decrement_strong_count_DepositEvent,
-    rustArcDecrementStrongCountPtr:
-        RustLib.instance.api.rust_arc_decrement_strong_count_DepositEventPtr,
-  );
-
-  DepositEventKind get eventKind => RustLib.instance.api
-      .crateMultimintDepositEventAutoAccessorGetEventKind(that: this);
-
-  FederationId get federationId => RustLib.instance.api
-      .crateMultimintDepositEventAutoAccessorGetFederationId(that: this);
-
-  set eventKind(DepositEventKind eventKind) =>
-      RustLib.instance.api.crateMultimintDepositEventAutoAccessorSetEventKind(
-        that: this,
-        eventKind: eventKind,
-      );
-
-  set federationId(FederationId federationId) => RustLib.instance.api
-      .crateMultimintDepositEventAutoAccessorSetFederationId(
-        that: this,
-        federationId: federationId,
-      );
 }
 
 @sealed
@@ -8231,6 +8592,44 @@ class InviteCodeImpl extends RustOpaque implements InviteCode {
 }
 
 @sealed
+class MultimintEventImpl extends RustOpaque implements MultimintEvent {
+  // Not to be used by end users
+  MultimintEventImpl.frbInternalDcoDecode(List<dynamic> wire)
+    : super.frbInternalDcoDecode(wire, _kStaticData);
+
+  // Not to be used by end users
+  MultimintEventImpl.frbInternalSseDecode(BigInt ptr, int externalSizeOnNative)
+    : super.frbInternalSseDecode(ptr, externalSizeOnNative, _kStaticData);
+
+  static final _kStaticData = RustArcStaticData(
+    rustArcIncrementStrongCount:
+        RustLib.instance.api.rust_arc_increment_strong_count_MultimintEvent,
+    rustArcDecrementStrongCount:
+        RustLib.instance.api.rust_arc_decrement_strong_count_MultimintEvent,
+    rustArcDecrementStrongCountPtr:
+        RustLib.instance.api.rust_arc_decrement_strong_count_MultimintEventPtr,
+  );
+
+  MultimintEventKind get eventKind => RustLib.instance.api
+      .crateMultimintMultimintEventAutoAccessorGetEventKind(that: this);
+
+  FederationId get federationId => RustLib.instance.api
+      .crateMultimintMultimintEventAutoAccessorGetFederationId(that: this);
+
+  set eventKind(MultimintEventKind eventKind) =>
+      RustLib.instance.api.crateMultimintMultimintEventAutoAccessorSetEventKind(
+        that: this,
+        eventKind: eventKind,
+      );
+
+  set federationId(FederationId federationId) => RustLib.instance.api
+      .crateMultimintMultimintEventAutoAccessorSetFederationId(
+        that: this,
+        federationId: federationId,
+      );
+}
+
+@sealed
 class MultimintImpl extends RustOpaque implements Multimint {
   // Not to be used by end users
   MultimintImpl.frbInternalDcoDecode(List<dynamic> wire)
@@ -8276,7 +8675,7 @@ class MultimintImpl extends RustOpaque implements Multimint {
     operationId: operationId,
   );
 
-  Future<FinalReceiveOperationState> awaitReceive({
+  Future<(FinalReceiveOperationState, BigInt)> awaitReceive({
     required FederationId federationId,
     required OperationId operationId,
   }) => RustLib.instance.api.crateMultimintMultimintAwaitReceive(
@@ -8424,12 +8823,15 @@ class MultimintImpl extends RustOpaque implements Multimint {
     amountMsats: amountMsats,
   );
 
-  Stream<DepositEvent> subscribeDeposits({
+  Stream<DepositEventKind> subscribeDeposits({
     required FederationId federationId,
   }) => RustLib.instance.api.crateMultimintMultimintSubscribeDeposits(
     that: this,
     federationId: federationId,
   );
+
+  Stream<MultimintEvent> subscribeMultimintEvents() => RustLib.instance.api
+      .crateMultimintMultimintSubscribeMultimintEvents(that: this);
 
   Future<List<Transaction>> transactions({
     required FederationId federationId,

--- a/lib/frb_generated.io.dart
+++ b/lib/frb_generated.io.dart
@@ -39,10 +39,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
       wire._rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDatabasePtr;
 
   CrossPlatformFinalizerArg
-  get rust_arc_decrement_strong_count_DepositEventPtr =>
-      wire._rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDepositEventPtr;
-
-  CrossPlatformFinalizerArg
   get rust_arc_decrement_strong_count_FederationConfigPtr =>
       wire._rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerFederationConfigPtr;
 
@@ -67,6 +63,10 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   CrossPlatformFinalizerArg get rust_arc_decrement_strong_count_MultimintPtr =>
       wire._rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMultimintPtr;
+
+  CrossPlatformFinalizerArg
+  get rust_arc_decrement_strong_count_MultimintEventPtr =>
+      wire._rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMultimintEventPtr;
 
   CrossPlatformFinalizerArg
   get rust_arc_decrement_strong_count_NostrClientPtr =>
@@ -125,12 +125,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
-  DepositEvent
-  dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDepositEvent(
-    dynamic raw,
-  );
-
-  @protected
   FederationConfig
   dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerFederationConfig(
     dynamic raw,
@@ -173,6 +167,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  MultimintEvent
+  dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMultimintEvent(
+    dynamic raw,
+  );
+
+  @protected
   NostrClient
   dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNostrClient(
     dynamic raw,
@@ -209,12 +209,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
-  DepositEvent
-  dco_decode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDepositEvent(
-    dynamic raw,
-  );
-
-  @protected
   FederationConfig
   dco_decode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerFederationConfig(
     dynamic raw,
@@ -233,6 +227,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  MultimintEvent
+  dco_decode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMultimintEvent(
+    dynamic raw,
+  );
+
+  @protected
   NostrClient
   dco_decode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNostrClient(
     dynamic raw,
@@ -241,12 +241,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   PublicFederation
   dco_decode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPublicFederation(
-    dynamic raw,
-  );
-
-  @protected
-  DepositEvent
-  dco_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDepositEvent(
     dynamic raw,
   );
 
@@ -271,6 +265,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   Multimint
   dco_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMultimint(
+    dynamic raw,
+  );
+
+  @protected
+  MultimintEvent
+  dco_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMultimintEvent(
     dynamic raw,
   );
 
@@ -317,12 +317,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
-  DepositEvent
-  dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDepositEvent(
-    dynamic raw,
-  );
-
-  @protected
   FederationConfig
   dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerFederationConfig(
     dynamic raw,
@@ -365,6 +359,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  MultimintEvent
+  dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMultimintEvent(
+    dynamic raw,
+  );
+
+  @protected
   NostrClient
   dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNostrClient(
     dynamic raw,
@@ -401,8 +401,13 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
-  RustStreamSink<DepositEvent>
-  dco_decode_StreamSink_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDepositEvent_Sse(
+  RustStreamSink<MultimintEvent>
+  dco_decode_StreamSink_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMultimintEvent_Sse(
+    dynamic raw,
+  );
+
+  @protected
+  RustStreamSink<DepositEventKind> dco_decode_StreamSink_deposit_event_kind_Sse(
     dynamic raw,
   );
 
@@ -423,6 +428,15 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   ConfirmedEvent dco_decode_box_autoadd_confirmed_event(dynamic raw);
+
+  @protected
+  DepositEventKind dco_decode_box_autoadd_deposit_event_kind(dynamic raw);
+
+  @protected
+  InvoicePaidEvent dco_decode_box_autoadd_invoice_paid_event(dynamic raw);
+
+  @protected
+  LightningEventKind dco_decode_box_autoadd_lightning_event_kind(dynamic raw);
 
   @protected
   MempoolEvent dco_decode_box_autoadd_mempool_event(dynamic raw);
@@ -447,6 +461,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   Guardian dco_decode_guardian(dynamic raw);
+
+  @protected
+  InvoicePaidEvent dco_decode_invoice_paid_event(dynamic raw);
+
+  @protected
+  LightningEventKind dco_decode_lightning_event_kind(dynamic raw);
 
   @protected
   List<PublicFederation>
@@ -485,6 +505,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   MultimintCreation dco_decode_multimint_creation(dynamic raw);
 
   @protected
+  MultimintEventKind dco_decode_multimint_event_kind(dynamic raw);
+
+  @protected
   NWCConnectionInfo dco_decode_nwc_connection_info(dynamic raw);
 
   @protected
@@ -514,6 +537,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   (FederationSelector, NWCConnectionInfo)
   dco_decode_record_auto_owned_rust_opaque_flutter_rust_bridgefor_generated_rust_auto_opaque_inner_federation_selector_nwc_connection_info(
+    dynamic raw,
+  );
+
+  @protected
+  (FinalReceiveOperationState, BigInt)
+  dco_decode_record_auto_owned_rust_opaque_flutter_rust_bridgefor_generated_rust_auto_opaque_inner_final_receive_operation_state_u_64(
     dynamic raw,
   );
 
@@ -596,12 +625,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
-  DepositEvent
-  sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDepositEvent(
-    SseDeserializer deserializer,
-  );
-
-  @protected
   FederationConfig
   sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerFederationConfig(
     SseDeserializer deserializer,
@@ -644,6 +667,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  MultimintEvent
+  sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMultimintEvent(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   NostrClient
   sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNostrClient(
     SseDeserializer deserializer,
@@ -680,12 +709,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
-  DepositEvent
-  sse_decode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDepositEvent(
-    SseDeserializer deserializer,
-  );
-
-  @protected
   FederationConfig
   sse_decode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerFederationConfig(
     SseDeserializer deserializer,
@@ -704,6 +727,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  MultimintEvent
+  sse_decode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMultimintEvent(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   NostrClient
   sse_decode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNostrClient(
     SseDeserializer deserializer,
@@ -712,12 +741,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   PublicFederation
   sse_decode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPublicFederation(
-    SseDeserializer deserializer,
-  );
-
-  @protected
-  DepositEvent
-  sse_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDepositEvent(
     SseDeserializer deserializer,
   );
 
@@ -742,6 +765,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   Multimint
   sse_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMultimint(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  MultimintEvent
+  sse_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMultimintEvent(
     SseDeserializer deserializer,
   );
 
@@ -788,12 +817,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
-  DepositEvent
-  sse_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDepositEvent(
-    SseDeserializer deserializer,
-  );
-
-  @protected
   FederationConfig
   sse_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerFederationConfig(
     SseDeserializer deserializer,
@@ -836,6 +859,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  MultimintEvent
+  sse_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMultimintEvent(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   NostrClient
   sse_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNostrClient(
     SseDeserializer deserializer,
@@ -872,8 +901,13 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
-  RustStreamSink<DepositEvent>
-  sse_decode_StreamSink_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDepositEvent_Sse(
+  RustStreamSink<MultimintEvent>
+  sse_decode_StreamSink_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMultimintEvent_Sse(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  RustStreamSink<DepositEventKind> sse_decode_StreamSink_deposit_event_kind_Sse(
     SseDeserializer deserializer,
   );
 
@@ -904,6 +938,21 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  DepositEventKind sse_decode_box_autoadd_deposit_event_kind(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  InvoicePaidEvent sse_decode_box_autoadd_invoice_paid_event(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  LightningEventKind sse_decode_box_autoadd_lightning_event_kind(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   MempoolEvent sse_decode_box_autoadd_mempool_event(
     SseDeserializer deserializer,
   );
@@ -930,6 +979,14 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   Guardian sse_decode_guardian(SseDeserializer deserializer);
+
+  @protected
+  InvoicePaidEvent sse_decode_invoice_paid_event(SseDeserializer deserializer);
+
+  @protected
+  LightningEventKind sse_decode_lightning_event_kind(
+    SseDeserializer deserializer,
+  );
 
   @protected
   List<PublicFederation>
@@ -968,6 +1025,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   MultimintCreation sse_decode_multimint_creation(SseDeserializer deserializer);
 
   @protected
+  MultimintEventKind sse_decode_multimint_event_kind(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   NWCConnectionInfo sse_decode_nwc_connection_info(
     SseDeserializer deserializer,
   );
@@ -999,6 +1061,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   (FederationSelector, NWCConnectionInfo)
   sse_decode_record_auto_owned_rust_opaque_flutter_rust_bridgefor_generated_rust_auto_opaque_inner_federation_selector_nwc_connection_info(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  (FinalReceiveOperationState, BigInt)
+  sse_decode_record_auto_owned_rust_opaque_flutter_rust_bridgefor_generated_rust_auto_opaque_inner_final_receive_operation_state_u_64(
     SseDeserializer deserializer,
   );
 
@@ -1095,13 +1163,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void
-  sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDepositEvent(
-    DepositEvent self,
-    SseSerializer serializer,
-  );
-
-  @protected
-  void
   sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerFederationConfig(
     FederationConfig self,
     SseSerializer serializer,
@@ -1151,6 +1212,13 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void
+  sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMultimintEvent(
+    MultimintEvent self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void
   sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNostrClient(
     NostrClient self,
     SseSerializer serializer,
@@ -1193,13 +1261,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void
-  sse_encode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDepositEvent(
-    DepositEvent self,
-    SseSerializer serializer,
-  );
-
-  @protected
-  void
   sse_encode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerFederationConfig(
     FederationConfig self,
     SseSerializer serializer,
@@ -1221,6 +1282,13 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void
+  sse_encode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMultimintEvent(
+    MultimintEvent self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void
   sse_encode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNostrClient(
     NostrClient self,
     SseSerializer serializer,
@@ -1230,13 +1298,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   void
   sse_encode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPublicFederation(
     PublicFederation self,
-    SseSerializer serializer,
-  );
-
-  @protected
-  void
-  sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDepositEvent(
-    DepositEvent self,
     SseSerializer serializer,
   );
 
@@ -1265,6 +1326,13 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   void
   sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMultimint(
     Multimint self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void
+  sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMultimintEvent(
+    MultimintEvent self,
     SseSerializer serializer,
   );
 
@@ -1319,13 +1387,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void
-  sse_encode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDepositEvent(
-    DepositEvent self,
-    SseSerializer serializer,
-  );
-
-  @protected
-  void
   sse_encode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerFederationConfig(
     FederationConfig self,
     SseSerializer serializer,
@@ -1375,6 +1436,13 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void
+  sse_encode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMultimintEvent(
+    MultimintEvent self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void
   sse_encode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNostrClient(
     NostrClient self,
     SseSerializer serializer,
@@ -1417,8 +1485,14 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void
-  sse_encode_StreamSink_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDepositEvent_Sse(
-    RustStreamSink<DepositEvent> self,
+  sse_encode_StreamSink_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMultimintEvent_Sse(
+    RustStreamSink<MultimintEvent> self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_StreamSink_deposit_event_kind_Sse(
+    RustStreamSink<DepositEventKind> self,
     SseSerializer serializer,
   );
 
@@ -1449,6 +1523,24 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_box_autoadd_confirmed_event(
     ConfirmedEvent self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_box_autoadd_deposit_event_kind(
+    DepositEventKind self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_box_autoadd_invoice_paid_event(
+    InvoicePaidEvent self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_box_autoadd_lightning_event_kind(
+    LightningEventKind self,
     SseSerializer serializer,
   );
 
@@ -1490,6 +1582,18 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void sse_encode_guardian(Guardian self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_invoice_paid_event(
+    InvoicePaidEvent self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_lightning_event_kind(
+    LightningEventKind self,
+    SseSerializer serializer,
+  );
 
   @protected
   void
@@ -1540,6 +1644,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  void sse_encode_multimint_event_kind(
+    MultimintEventKind self,
+    SseSerializer serializer,
+  );
+
+  @protected
   void sse_encode_nwc_connection_info(
     NWCConnectionInfo self,
     SseSerializer serializer,
@@ -1581,6 +1691,13 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   void
   sse_encode_record_auto_owned_rust_opaque_flutter_rust_bridgefor_generated_rust_auto_opaque_inner_federation_selector_nwc_connection_info(
     (FederationSelector, NWCConnectionInfo) self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void
+  sse_encode_record_auto_owned_rust_opaque_flutter_rust_bridgefor_generated_rust_auto_opaque_inner_final_receive_operation_state_u_64(
+    (FinalReceiveOperationState, BigInt) self,
     SseSerializer serializer,
   );
 
@@ -1828,40 +1945,6 @@ class RustLibWire implements BaseWire {
           .asFunction<void Function(ffi.Pointer<ffi.Void>)>();
 
   void
-  rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDepositEvent(
-    ffi.Pointer<ffi.Void> ptr,
-  ) {
-    return _rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDepositEvent(
-      ptr,
-    );
-  }
-
-  late final _rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDepositEventPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>)>>(
-        'frbgen_carbine_rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDepositEvent',
-      );
-  late final _rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDepositEvent =
-      _rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDepositEventPtr
-          .asFunction<void Function(ffi.Pointer<ffi.Void>)>();
-
-  void
-  rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDepositEvent(
-    ffi.Pointer<ffi.Void> ptr,
-  ) {
-    return _rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDepositEvent(
-      ptr,
-    );
-  }
-
-  late final _rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDepositEventPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>)>>(
-        'frbgen_carbine_rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDepositEvent',
-      );
-  late final _rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDepositEvent =
-      _rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDepositEventPtr
-          .asFunction<void Function(ffi.Pointer<ffi.Void>)>();
-
-  void
   rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerFederationConfig(
     ffi.Pointer<ffi.Void> ptr,
   ) {
@@ -2097,6 +2180,40 @@ class RustLibWire implements BaseWire {
       );
   late final _rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMultimint =
       _rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMultimintPtr
+          .asFunction<void Function(ffi.Pointer<ffi.Void>)>();
+
+  void
+  rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMultimintEvent(
+    ffi.Pointer<ffi.Void> ptr,
+  ) {
+    return _rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMultimintEvent(
+      ptr,
+    );
+  }
+
+  late final _rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMultimintEventPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>)>>(
+        'frbgen_carbine_rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMultimintEvent',
+      );
+  late final _rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMultimintEvent =
+      _rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMultimintEventPtr
+          .asFunction<void Function(ffi.Pointer<ffi.Void>)>();
+
+  void
+  rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMultimintEvent(
+    ffi.Pointer<ffi.Void> ptr,
+  ) {
+    return _rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMultimintEvent(
+      ptr,
+    );
+  }
+
+  late final _rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMultimintEventPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>)>>(
+        'frbgen_carbine_rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMultimintEvent',
+      );
+  late final _rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMultimintEvent =
+      _rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMultimintEventPtr
           .asFunction<void Function(ffi.Pointer<ffi.Void>)>();
 
   void

--- a/lib/frb_generated.web.dart
+++ b/lib/frb_generated.web.dart
@@ -41,10 +41,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
       wire.rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDatabase;
 
   CrossPlatformFinalizerArg
-  get rust_arc_decrement_strong_count_DepositEventPtr =>
-      wire.rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDepositEvent;
-
-  CrossPlatformFinalizerArg
   get rust_arc_decrement_strong_count_FederationConfigPtr =>
       wire.rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerFederationConfig;
 
@@ -69,6 +65,10 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   CrossPlatformFinalizerArg get rust_arc_decrement_strong_count_MultimintPtr =>
       wire.rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMultimint;
+
+  CrossPlatformFinalizerArg
+  get rust_arc_decrement_strong_count_MultimintEventPtr =>
+      wire.rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMultimintEvent;
 
   CrossPlatformFinalizerArg
   get rust_arc_decrement_strong_count_NostrClientPtr =>
@@ -127,12 +127,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
-  DepositEvent
-  dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDepositEvent(
-    dynamic raw,
-  );
-
-  @protected
   FederationConfig
   dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerFederationConfig(
     dynamic raw,
@@ -175,6 +169,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  MultimintEvent
+  dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMultimintEvent(
+    dynamic raw,
+  );
+
+  @protected
   NostrClient
   dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNostrClient(
     dynamic raw,
@@ -211,12 +211,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
-  DepositEvent
-  dco_decode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDepositEvent(
-    dynamic raw,
-  );
-
-  @protected
   FederationConfig
   dco_decode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerFederationConfig(
     dynamic raw,
@@ -235,6 +229,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  MultimintEvent
+  dco_decode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMultimintEvent(
+    dynamic raw,
+  );
+
+  @protected
   NostrClient
   dco_decode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNostrClient(
     dynamic raw,
@@ -243,12 +243,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   PublicFederation
   dco_decode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPublicFederation(
-    dynamic raw,
-  );
-
-  @protected
-  DepositEvent
-  dco_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDepositEvent(
     dynamic raw,
   );
 
@@ -273,6 +267,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   Multimint
   dco_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMultimint(
+    dynamic raw,
+  );
+
+  @protected
+  MultimintEvent
+  dco_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMultimintEvent(
     dynamic raw,
   );
 
@@ -319,12 +319,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
-  DepositEvent
-  dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDepositEvent(
-    dynamic raw,
-  );
-
-  @protected
   FederationConfig
   dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerFederationConfig(
     dynamic raw,
@@ -367,6 +361,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  MultimintEvent
+  dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMultimintEvent(
+    dynamic raw,
+  );
+
+  @protected
   NostrClient
   dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNostrClient(
     dynamic raw,
@@ -403,8 +403,13 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
-  RustStreamSink<DepositEvent>
-  dco_decode_StreamSink_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDepositEvent_Sse(
+  RustStreamSink<MultimintEvent>
+  dco_decode_StreamSink_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMultimintEvent_Sse(
+    dynamic raw,
+  );
+
+  @protected
+  RustStreamSink<DepositEventKind> dco_decode_StreamSink_deposit_event_kind_Sse(
     dynamic raw,
   );
 
@@ -425,6 +430,15 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   ConfirmedEvent dco_decode_box_autoadd_confirmed_event(dynamic raw);
+
+  @protected
+  DepositEventKind dco_decode_box_autoadd_deposit_event_kind(dynamic raw);
+
+  @protected
+  InvoicePaidEvent dco_decode_box_autoadd_invoice_paid_event(dynamic raw);
+
+  @protected
+  LightningEventKind dco_decode_box_autoadd_lightning_event_kind(dynamic raw);
 
   @protected
   MempoolEvent dco_decode_box_autoadd_mempool_event(dynamic raw);
@@ -449,6 +463,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   Guardian dco_decode_guardian(dynamic raw);
+
+  @protected
+  InvoicePaidEvent dco_decode_invoice_paid_event(dynamic raw);
+
+  @protected
+  LightningEventKind dco_decode_lightning_event_kind(dynamic raw);
 
   @protected
   List<PublicFederation>
@@ -487,6 +507,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   MultimintCreation dco_decode_multimint_creation(dynamic raw);
 
   @protected
+  MultimintEventKind dco_decode_multimint_event_kind(dynamic raw);
+
+  @protected
   NWCConnectionInfo dco_decode_nwc_connection_info(dynamic raw);
 
   @protected
@@ -516,6 +539,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   (FederationSelector, NWCConnectionInfo)
   dco_decode_record_auto_owned_rust_opaque_flutter_rust_bridgefor_generated_rust_auto_opaque_inner_federation_selector_nwc_connection_info(
+    dynamic raw,
+  );
+
+  @protected
+  (FinalReceiveOperationState, BigInt)
+  dco_decode_record_auto_owned_rust_opaque_flutter_rust_bridgefor_generated_rust_auto_opaque_inner_final_receive_operation_state_u_64(
     dynamic raw,
   );
 
@@ -598,12 +627,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
-  DepositEvent
-  sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDepositEvent(
-    SseDeserializer deserializer,
-  );
-
-  @protected
   FederationConfig
   sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerFederationConfig(
     SseDeserializer deserializer,
@@ -646,6 +669,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  MultimintEvent
+  sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMultimintEvent(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   NostrClient
   sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNostrClient(
     SseDeserializer deserializer,
@@ -682,12 +711,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
-  DepositEvent
-  sse_decode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDepositEvent(
-    SseDeserializer deserializer,
-  );
-
-  @protected
   FederationConfig
   sse_decode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerFederationConfig(
     SseDeserializer deserializer,
@@ -706,6 +729,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  MultimintEvent
+  sse_decode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMultimintEvent(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   NostrClient
   sse_decode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNostrClient(
     SseDeserializer deserializer,
@@ -714,12 +743,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   PublicFederation
   sse_decode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPublicFederation(
-    SseDeserializer deserializer,
-  );
-
-  @protected
-  DepositEvent
-  sse_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDepositEvent(
     SseDeserializer deserializer,
   );
 
@@ -744,6 +767,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   Multimint
   sse_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMultimint(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  MultimintEvent
+  sse_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMultimintEvent(
     SseDeserializer deserializer,
   );
 
@@ -790,12 +819,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
-  DepositEvent
-  sse_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDepositEvent(
-    SseDeserializer deserializer,
-  );
-
-  @protected
   FederationConfig
   sse_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerFederationConfig(
     SseDeserializer deserializer,
@@ -838,6 +861,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  MultimintEvent
+  sse_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMultimintEvent(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   NostrClient
   sse_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNostrClient(
     SseDeserializer deserializer,
@@ -874,8 +903,13 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
-  RustStreamSink<DepositEvent>
-  sse_decode_StreamSink_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDepositEvent_Sse(
+  RustStreamSink<MultimintEvent>
+  sse_decode_StreamSink_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMultimintEvent_Sse(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  RustStreamSink<DepositEventKind> sse_decode_StreamSink_deposit_event_kind_Sse(
     SseDeserializer deserializer,
   );
 
@@ -906,6 +940,21 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  DepositEventKind sse_decode_box_autoadd_deposit_event_kind(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  InvoicePaidEvent sse_decode_box_autoadd_invoice_paid_event(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  LightningEventKind sse_decode_box_autoadd_lightning_event_kind(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   MempoolEvent sse_decode_box_autoadd_mempool_event(
     SseDeserializer deserializer,
   );
@@ -932,6 +981,14 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   Guardian sse_decode_guardian(SseDeserializer deserializer);
+
+  @protected
+  InvoicePaidEvent sse_decode_invoice_paid_event(SseDeserializer deserializer);
+
+  @protected
+  LightningEventKind sse_decode_lightning_event_kind(
+    SseDeserializer deserializer,
+  );
 
   @protected
   List<PublicFederation>
@@ -970,6 +1027,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   MultimintCreation sse_decode_multimint_creation(SseDeserializer deserializer);
 
   @protected
+  MultimintEventKind sse_decode_multimint_event_kind(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   NWCConnectionInfo sse_decode_nwc_connection_info(
     SseDeserializer deserializer,
   );
@@ -1001,6 +1063,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   (FederationSelector, NWCConnectionInfo)
   sse_decode_record_auto_owned_rust_opaque_flutter_rust_bridgefor_generated_rust_auto_opaque_inner_federation_selector_nwc_connection_info(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  (FinalReceiveOperationState, BigInt)
+  sse_decode_record_auto_owned_rust_opaque_flutter_rust_bridgefor_generated_rust_auto_opaque_inner_final_receive_operation_state_u_64(
     SseDeserializer deserializer,
   );
 
@@ -1097,13 +1165,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void
-  sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDepositEvent(
-    DepositEvent self,
-    SseSerializer serializer,
-  );
-
-  @protected
-  void
   sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerFederationConfig(
     FederationConfig self,
     SseSerializer serializer,
@@ -1153,6 +1214,13 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void
+  sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMultimintEvent(
+    MultimintEvent self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void
   sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNostrClient(
     NostrClient self,
     SseSerializer serializer,
@@ -1195,13 +1263,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void
-  sse_encode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDepositEvent(
-    DepositEvent self,
-    SseSerializer serializer,
-  );
-
-  @protected
-  void
   sse_encode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerFederationConfig(
     FederationConfig self,
     SseSerializer serializer,
@@ -1223,6 +1284,13 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void
+  sse_encode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMultimintEvent(
+    MultimintEvent self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void
   sse_encode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNostrClient(
     NostrClient self,
     SseSerializer serializer,
@@ -1232,13 +1300,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   void
   sse_encode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPublicFederation(
     PublicFederation self,
-    SseSerializer serializer,
-  );
-
-  @protected
-  void
-  sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDepositEvent(
-    DepositEvent self,
     SseSerializer serializer,
   );
 
@@ -1267,6 +1328,13 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   void
   sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMultimint(
     Multimint self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void
+  sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMultimintEvent(
+    MultimintEvent self,
     SseSerializer serializer,
   );
 
@@ -1321,13 +1389,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void
-  sse_encode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDepositEvent(
-    DepositEvent self,
-    SseSerializer serializer,
-  );
-
-  @protected
-  void
   sse_encode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerFederationConfig(
     FederationConfig self,
     SseSerializer serializer,
@@ -1377,6 +1438,13 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void
+  sse_encode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMultimintEvent(
+    MultimintEvent self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void
   sse_encode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNostrClient(
     NostrClient self,
     SseSerializer serializer,
@@ -1419,8 +1487,14 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void
-  sse_encode_StreamSink_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDepositEvent_Sse(
-    RustStreamSink<DepositEvent> self,
+  sse_encode_StreamSink_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMultimintEvent_Sse(
+    RustStreamSink<MultimintEvent> self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_StreamSink_deposit_event_kind_Sse(
+    RustStreamSink<DepositEventKind> self,
     SseSerializer serializer,
   );
 
@@ -1451,6 +1525,24 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_box_autoadd_confirmed_event(
     ConfirmedEvent self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_box_autoadd_deposit_event_kind(
+    DepositEventKind self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_box_autoadd_invoice_paid_event(
+    InvoicePaidEvent self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_box_autoadd_lightning_event_kind(
+    LightningEventKind self,
     SseSerializer serializer,
   );
 
@@ -1492,6 +1584,18 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void sse_encode_guardian(Guardian self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_invoice_paid_event(
+    InvoicePaidEvent self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_lightning_event_kind(
+    LightningEventKind self,
+    SseSerializer serializer,
+  );
 
   @protected
   void
@@ -1542,6 +1646,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  void sse_encode_multimint_event_kind(
+    MultimintEventKind self,
+    SseSerializer serializer,
+  );
+
+  @protected
   void sse_encode_nwc_connection_info(
     NWCConnectionInfo self,
     SseSerializer serializer,
@@ -1583,6 +1693,13 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   void
   sse_encode_record_auto_owned_rust_opaque_flutter_rust_bridgefor_generated_rust_auto_opaque_inner_federation_selector_nwc_connection_info(
     (FederationSelector, NWCConnectionInfo) self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void
+  sse_encode_record_auto_owned_rust_opaque_flutter_rust_bridgefor_generated_rust_auto_opaque_inner_final_receive_operation_state_u_64(
+    (FinalReceiveOperationState, BigInt) self,
     SseSerializer serializer,
   );
 
@@ -1731,22 +1848,6 @@ class RustLibWire implements BaseWire {
       );
 
   void
-  rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDepositEvent(
-    int ptr,
-  ) => wasmModule
-      .rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDepositEvent(
-        ptr,
-      );
-
-  void
-  rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDepositEvent(
-    int ptr,
-  ) => wasmModule
-      .rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDepositEvent(
-        ptr,
-      );
-
-  void
   rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerFederationConfig(
     int ptr,
   ) => wasmModule
@@ -1855,6 +1956,22 @@ class RustLibWire implements BaseWire {
     int ptr,
   ) => wasmModule
       .rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMultimint(
+        ptr,
+      );
+
+  void
+  rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMultimintEvent(
+    int ptr,
+  ) => wasmModule
+      .rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMultimintEvent(
+        ptr,
+      );
+
+  void
+  rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMultimintEvent(
+    int ptr,
+  ) => wasmModule
+      .rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMultimintEvent(
         ptr,
       );
 
@@ -2012,16 +2129,6 @@ extension type RustLibWasmModule._(JSObject _) implements JSObject {
   );
 
   external void
-  rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDepositEvent(
-    int ptr,
-  );
-
-  external void
-  rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDepositEvent(
-    int ptr,
-  );
-
-  external void
   rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerFederationConfig(
     int ptr,
   );
@@ -2088,6 +2195,16 @@ extension type RustLibWasmModule._(JSObject _) implements JSObject {
 
   external void
   rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMultimint(
+    int ptr,
+  );
+
+  external void
+  rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMultimintEvent(
+    int ptr,
+  );
+
+  external void
+  rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMultimintEvent(
     int ptr,
   );
 

--- a/lib/lib.dart
+++ b/lib/lib.dart
@@ -98,7 +98,7 @@ Future<(FinalSendOperationState, String)> awaitSend({
   operationId: operationId,
 );
 
-Future<FinalReceiveOperationState> awaitReceive({
+Future<(FinalReceiveOperationState, BigInt)> awaitReceive({
   required FederationId federationId,
   required OperationId operationId,
 }) => RustLib.instance.api.crateAwaitReceive(
@@ -185,8 +185,9 @@ Future<void> ackSeedPhrase() => RustLib.instance.api.crateAckSeedPhrase();
 
 Future<List<String>> wordList() => RustLib.instance.api.crateWordList();
 
-Stream<DepositEvent> subscribeDeposits({required FederationId federationId}) =>
-    RustLib.instance.api.crateSubscribeDeposits(federationId: federationId);
+Stream<DepositEventKind> subscribeDeposits({
+  required FederationId federationId,
+}) => RustLib.instance.api.crateSubscribeDeposits(federationId: federationId);
 
 Future<void> monitorDepositAddress({
   required FederationId federationId,
@@ -213,6 +214,12 @@ Future<NWCConnectionInfo> setNwcConnectionInfo({
 );
 
 Future<List<String>> getRelays() => RustLib.instance.api.crateGetRelays();
+
+Stream<MultimintEvent> subscribeMultimintEvents() =>
+    RustLib.instance.api.crateSubscribeMultimintEvents();
+
+Future<String> federationIdToString({required FederationId federationId}) =>
+    RustLib.instance.api.crateFederationIdToString(federationId: federationId);
 
 // Rust type: RustOpaqueMoi<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<ClientConfig>>
 abstract class ClientConfig implements RustOpaqueInterface {}

--- a/lib/multimint.dart
+++ b/lib/multimint.dart
@@ -9,26 +9,15 @@ import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 import 'package:freezed_annotation/freezed_annotation.dart' hide protected;
 part 'multimint.freezed.dart';
 
-// These functions are ignored because they are not marked as `pub`: `_has_federation`, `await_receive_lnv1`, `await_receive_lnv2`, `await_send_lnv1`, `await_send_lnv2`, `build_client`, `compute_receive_amount`, `compute_send_amount`, `derive_federation_secret`, `finish_active_subscriptions`, `get_client_database`, `invoice_routes_back_to_federation`, `lnv1_select_gateway`, `lnv1_update_gateway_cache`, `lnv2_select_gateway`, `load_clients`, `monitor_all_unused_pegin_addresses`, `pay_lnv1`, `pay_lnv2`, `receive_amount_after_fees`, `receive_lnv1`, `receive_lnv2`, `spawn_await_ecash_reissue`, `spawn_await_ecash_send`, `spawn_await_receive`, `spawn_await_send`, `spawn_pegin_address_watcher`, `spawn_recovery_progress`, `watch_pegin_address`
+// These functions are ignored because they are not marked as `pub`: `_has_federation`, `await_receive_lnv1`, `await_receive_lnv2`, `await_send_lnv1`, `await_send_lnv2`, `build_client`, `compute_receive_amount`, `compute_send_amount`, `derive_federation_secret`, `finish_active_subscriptions`, `get_client_database`, `get_lnv1_amount_from_meta`, `get_lnv2_amount_from_meta`, `invoice_routes_back_to_federation`, `lnv1_select_gateway`, `lnv1_update_gateway_cache`, `lnv2_select_gateway`, `load_clients`, `monitor_all_unused_pegin_addresses`, `pay_lnv1`, `pay_lnv2`, `receive_amount_after_fees`, `receive_lnv1`, `receive_lnv2`, `spawn_await_ecash_reissue`, `spawn_await_ecash_send`, `spawn_await_receive`, `spawn_await_send`, `spawn_pegin_address_watcher`, `spawn_recovery_progress`, `watch_pegin_address`
 // These types are ignored because they are neither used by any `pub` functions nor (for structs and enums) marked `#[frb(unignore)]`: `ClientType`
-// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`
+// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`
 
 // Rust type: RustOpaqueMoi<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<Amount>>
 abstract class Amount implements RustOpaqueInterface {}
 
 // Rust type: RustOpaqueMoi<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<Bolt11Invoice>>
 abstract class Bolt11Invoice implements RustOpaqueInterface {}
-
-// Rust type: RustOpaqueMoi<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<DepositEvent>>
-abstract class DepositEvent implements RustOpaqueInterface {
-  DepositEventKind get eventKind;
-
-  FederationId get federationId;
-
-  set eventKind(DepositEventKind eventKind);
-
-  set federationId(FederationId federationId);
-}
 
 // Rust type: RustOpaqueMoi<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<FederationSelector>>
 abstract class FederationSelector implements RustOpaqueInterface {
@@ -71,7 +60,7 @@ abstract class Multimint implements RustOpaqueInterface {
     required OperationId operationId,
   });
 
-  Future<FinalReceiveOperationState> awaitReceive({
+  Future<(FinalReceiveOperationState, BigInt)> awaitReceive({
     required FederationId federationId,
     required OperationId operationId,
   });
@@ -161,7 +150,11 @@ abstract class Multimint implements RustOpaqueInterface {
     required BigInt amountMsats,
   });
 
-  Stream<DepositEvent> subscribeDeposits({required FederationId federationId});
+  Stream<DepositEventKind> subscribeDeposits({
+    required FederationId federationId,
+  });
+
+  Stream<MultimintEvent> subscribeMultimintEvents();
 
   Future<List<Transaction>> transactions({
     required FederationId federationId,
@@ -171,6 +164,17 @@ abstract class Multimint implements RustOpaqueInterface {
   });
 
   Future<FederationSelector> waitForRecovery({required String inviteCode});
+}
+
+// Rust type: RustOpaqueMoi<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<MultimintEvent>>
+abstract class MultimintEvent implements RustOpaqueInterface {
+  MultimintEventKind get eventKind;
+
+  FederationId get federationId;
+
+  set eventKind(MultimintEventKind eventKind);
+
+  set federationId(FederationId federationId);
 }
 
 // Rust type: RustOpaqueMoi<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<OperationId>>
@@ -301,6 +305,30 @@ class Guardian {
           version == other.version;
 }
 
+class InvoicePaidEvent {
+  final BigInt amountMsats;
+
+  const InvoicePaidEvent({required this.amountMsats});
+
+  @override
+  int get hashCode => amountMsats.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is InvoicePaidEvent &&
+          runtimeType == other.runtimeType &&
+          amountMsats == other.amountMsats;
+}
+
+@freezed
+sealed class LightningEventKind with _$LightningEventKind {
+  const LightningEventKind._();
+
+  const factory LightningEventKind.invoicePaid(InvoicePaidEvent field0) =
+      LightningEventKind_InvoicePaid;
+}
+
 class MempoolEvent {
   final BigInt amount;
   final String txid;
@@ -329,6 +357,16 @@ sealed class MultimintCreation with _$MultimintCreation {
   const factory MultimintCreation.newFromMnemonic({
     required List<String> words,
   }) = MultimintCreation_NewFromMnemonic;
+}
+
+@freezed
+sealed class MultimintEventKind with _$MultimintEventKind {
+  const MultimintEventKind._();
+
+  const factory MultimintEventKind.deposit(DepositEventKind field0) =
+      MultimintEventKind_Deposit;
+  const factory MultimintEventKind.lightning(LightningEventKind field0) =
+      MultimintEventKind_Lightning;
 }
 
 class PaymentPreview {

--- a/lib/multimint.freezed.dart
+++ b/lib/multimint.freezed.dart
@@ -307,6 +307,133 @@ as ClaimedEvent,
 }
 
 /// @nodoc
+mixin _$LightningEventKind {
+
+ InvoicePaidEvent get field0;
+/// Create a copy of LightningEventKind
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$LightningEventKindCopyWith<LightningEventKind> get copyWith => _$LightningEventKindCopyWithImpl<LightningEventKind>(this as LightningEventKind, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is LightningEventKind&&(identical(other.field0, field0) || other.field0 == field0));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,field0);
+
+@override
+String toString() {
+  return 'LightningEventKind(field0: $field0)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $LightningEventKindCopyWith<$Res>  {
+  factory $LightningEventKindCopyWith(LightningEventKind value, $Res Function(LightningEventKind) _then) = _$LightningEventKindCopyWithImpl;
+@useResult
+$Res call({
+ InvoicePaidEvent field0
+});
+
+
+
+
+}
+/// @nodoc
+class _$LightningEventKindCopyWithImpl<$Res>
+    implements $LightningEventKindCopyWith<$Res> {
+  _$LightningEventKindCopyWithImpl(this._self, this._then);
+
+  final LightningEventKind _self;
+  final $Res Function(LightningEventKind) _then;
+
+/// Create a copy of LightningEventKind
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? field0 = null,}) {
+  return _then(_self.copyWith(
+field0: null == field0 ? _self.field0 : field0 // ignore: cast_nullable_to_non_nullable
+as InvoicePaidEvent,
+  ));
+}
+
+}
+
+
+/// @nodoc
+
+
+class LightningEventKind_InvoicePaid extends LightningEventKind {
+  const LightningEventKind_InvoicePaid(this.field0): super._();
+  
+
+@override final  InvoicePaidEvent field0;
+
+/// Create a copy of LightningEventKind
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$LightningEventKind_InvoicePaidCopyWith<LightningEventKind_InvoicePaid> get copyWith => _$LightningEventKind_InvoicePaidCopyWithImpl<LightningEventKind_InvoicePaid>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is LightningEventKind_InvoicePaid&&(identical(other.field0, field0) || other.field0 == field0));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,field0);
+
+@override
+String toString() {
+  return 'LightningEventKind.invoicePaid(field0: $field0)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $LightningEventKind_InvoicePaidCopyWith<$Res> implements $LightningEventKindCopyWith<$Res> {
+  factory $LightningEventKind_InvoicePaidCopyWith(LightningEventKind_InvoicePaid value, $Res Function(LightningEventKind_InvoicePaid) _then) = _$LightningEventKind_InvoicePaidCopyWithImpl;
+@override @useResult
+$Res call({
+ InvoicePaidEvent field0
+});
+
+
+
+
+}
+/// @nodoc
+class _$LightningEventKind_InvoicePaidCopyWithImpl<$Res>
+    implements $LightningEventKind_InvoicePaidCopyWith<$Res> {
+  _$LightningEventKind_InvoicePaidCopyWithImpl(this._self, this._then);
+
+  final LightningEventKind_InvoicePaid _self;
+  final $Res Function(LightningEventKind_InvoicePaid) _then;
+
+/// Create a copy of LightningEventKind
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? field0 = null,}) {
+  return _then(LightningEventKind_InvoicePaid(
+null == field0 ? _self.field0 : field0 // ignore: cast_nullable_to_non_nullable
+as InvoicePaidEvent,
+  ));
+}
+
+
+}
+
+/// @nodoc
 mixin _$MultimintCreation {
 
 
@@ -470,6 +597,186 @@ as List<String>,
 }
 
 
+}
+
+/// @nodoc
+mixin _$MultimintEventKind {
+
+ Object get field0;
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is MultimintEventKind&&const DeepCollectionEquality().equals(other.field0, field0));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(field0));
+
+@override
+String toString() {
+  return 'MultimintEventKind(field0: $field0)';
+}
+
+
+}
+
+/// @nodoc
+class $MultimintEventKindCopyWith<$Res>  {
+$MultimintEventKindCopyWith(MultimintEventKind _, $Res Function(MultimintEventKind) __);
+}
+
+
+/// @nodoc
+
+
+class MultimintEventKind_Deposit extends MultimintEventKind {
+  const MultimintEventKind_Deposit(this.field0): super._();
+  
+
+@override final  DepositEventKind field0;
+
+/// Create a copy of MultimintEventKind
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$MultimintEventKind_DepositCopyWith<MultimintEventKind_Deposit> get copyWith => _$MultimintEventKind_DepositCopyWithImpl<MultimintEventKind_Deposit>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is MultimintEventKind_Deposit&&(identical(other.field0, field0) || other.field0 == field0));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,field0);
+
+@override
+String toString() {
+  return 'MultimintEventKind.deposit(field0: $field0)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $MultimintEventKind_DepositCopyWith<$Res> implements $MultimintEventKindCopyWith<$Res> {
+  factory $MultimintEventKind_DepositCopyWith(MultimintEventKind_Deposit value, $Res Function(MultimintEventKind_Deposit) _then) = _$MultimintEventKind_DepositCopyWithImpl;
+@useResult
+$Res call({
+ DepositEventKind field0
+});
+
+
+$DepositEventKindCopyWith<$Res> get field0;
+
+}
+/// @nodoc
+class _$MultimintEventKind_DepositCopyWithImpl<$Res>
+    implements $MultimintEventKind_DepositCopyWith<$Res> {
+  _$MultimintEventKind_DepositCopyWithImpl(this._self, this._then);
+
+  final MultimintEventKind_Deposit _self;
+  final $Res Function(MultimintEventKind_Deposit) _then;
+
+/// Create a copy of MultimintEventKind
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? field0 = null,}) {
+  return _then(MultimintEventKind_Deposit(
+null == field0 ? _self.field0 : field0 // ignore: cast_nullable_to_non_nullable
+as DepositEventKind,
+  ));
+}
+
+/// Create a copy of MultimintEventKind
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$DepositEventKindCopyWith<$Res> get field0 {
+  
+  return $DepositEventKindCopyWith<$Res>(_self.field0, (value) {
+    return _then(_self.copyWith(field0: value));
+  });
+}
+}
+
+/// @nodoc
+
+
+class MultimintEventKind_Lightning extends MultimintEventKind {
+  const MultimintEventKind_Lightning(this.field0): super._();
+  
+
+@override final  LightningEventKind field0;
+
+/// Create a copy of MultimintEventKind
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$MultimintEventKind_LightningCopyWith<MultimintEventKind_Lightning> get copyWith => _$MultimintEventKind_LightningCopyWithImpl<MultimintEventKind_Lightning>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is MultimintEventKind_Lightning&&(identical(other.field0, field0) || other.field0 == field0));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,field0);
+
+@override
+String toString() {
+  return 'MultimintEventKind.lightning(field0: $field0)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $MultimintEventKind_LightningCopyWith<$Res> implements $MultimintEventKindCopyWith<$Res> {
+  factory $MultimintEventKind_LightningCopyWith(MultimintEventKind_Lightning value, $Res Function(MultimintEventKind_Lightning) _then) = _$MultimintEventKind_LightningCopyWithImpl;
+@useResult
+$Res call({
+ LightningEventKind field0
+});
+
+
+$LightningEventKindCopyWith<$Res> get field0;
+
+}
+/// @nodoc
+class _$MultimintEventKind_LightningCopyWithImpl<$Res>
+    implements $MultimintEventKind_LightningCopyWith<$Res> {
+  _$MultimintEventKind_LightningCopyWithImpl(this._self, this._then);
+
+  final MultimintEventKind_Lightning _self;
+  final $Res Function(MultimintEventKind_Lightning) _then;
+
+/// Create a copy of MultimintEventKind
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? field0 = null,}) {
+  return _then(MultimintEventKind_Lightning(
+null == field0 ? _self.field0 : field0 // ignore: cast_nullable_to_non_nullable
+as LightningEventKind,
+  ));
+}
+
+/// Create a copy of MultimintEventKind
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$LightningEventKindCopyWith<$Res> get field0 {
+  
+  return $LightningEventKindCopyWith<$Res>(_self.field0, (value) {
+    return _then(_self.copyWith(field0: value));
+  });
+}
 }
 
 // dart format on

--- a/lib/number_pad.dart
+++ b/lib/number_pad.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:carbine/app.dart';
 import 'package:carbine/ecash_send.dart';
 import 'package:carbine/lib.dart';
 import 'package:carbine/multimint.dart';
@@ -95,7 +96,8 @@ class _NumberPadState extends State<NumberPad> {
           gateway: gateway.$1,
           isLnv2: gateway.$3,
         );
-        showCarbineModalBottomSheet(
+        invoicePaidToastVisible.value = false;
+        await showCarbineModalBottomSheet(
           context: context,
           child: Request(
             invoice: invoice.$1,
@@ -109,6 +111,7 @@ class _NumberPadState extends State<NumberPad> {
             expiry: invoice.$5,
           ),
         );
+        invoicePaidToastVisible.value = true;
       } else if (widget.paymentType == PaymentType.ecash) {
         showCarbineModalBottomSheet(
           context: context,

--- a/lib/toast.dart
+++ b/lib/toast.dart
@@ -1,0 +1,180 @@
+import 'dart:async';
+import 'package:flutter/material.dart';
+
+class ToastService {
+  static final ToastService _instance = ToastService._internal();
+  factory ToastService() => _instance;
+  ToastService._internal();
+
+  final GlobalKey<NavigatorState> navigatorKey = GlobalKey<NavigatorState>();
+  OverlayEntry? _currentToast;
+
+  void show({
+    required String message,
+    required Duration duration,
+    required VoidCallback onTap,
+  }) {
+    final context = navigatorKey.currentContext;
+    if (context == null) {
+      debugPrint('ToastService: No context available');
+      return;
+    }
+
+    _currentToast?.remove();
+
+    final entry = OverlayEntry(
+      builder:
+          (_) => _ToastWidget(
+            message: message,
+            duration: duration,
+            onTap: onTap,
+            onDismissed: () {
+              _currentToast?.remove();
+              _currentToast = null;
+            },
+          ),
+    );
+
+    _currentToast = entry;
+    Overlay.of(context).insert(entry);
+  }
+}
+
+class _ToastWidget extends StatefulWidget {
+  final String message;
+  final Duration duration;
+  final VoidCallback onTap;
+  final VoidCallback onDismissed;
+
+  const _ToastWidget({
+    required this.message,
+    required this.duration,
+    required this.onTap,
+    required this.onDismissed,
+  });
+
+  @override
+  State<_ToastWidget> createState() => _ToastWidgetState();
+}
+
+class _ToastWidgetState extends State<_ToastWidget>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+  late final Animation<Offset> _slideAnimation;
+  late final Animation<double> _fadeAnimation;
+  late final ValueNotifier<double> _progress;
+
+  @override
+  void initState() {
+    super.initState();
+
+    _progress = ValueNotifier(1.0);
+
+    _controller = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 300),
+    );
+
+    _slideAnimation = Tween<Offset>(
+      begin: const Offset(0, 1),
+      end: Offset.zero,
+    ).animate(CurvedAnimation(parent: _controller, curve: Curves.easeOut));
+
+    _fadeAnimation = CurvedAnimation(parent: _controller, curve: Curves.easeIn);
+
+    _controller.forward();
+
+    final startTime = DateTime.now();
+    Timer.periodic(const Duration(milliseconds: 50), (timer) {
+      final elapsed = DateTime.now().difference(startTime).inMilliseconds;
+      final total = widget.duration.inMilliseconds;
+      if (!mounted) return;
+      if (elapsed >= total) {
+        timer.cancel();
+        _controller.reverse().then((_) => widget.onDismissed());
+      } else {
+        _progress.value = 1 - elapsed / total;
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    _progress.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Positioned(
+      bottom: 50,
+      left: 20,
+      right: 20,
+      child: SlideTransition(
+        position: _slideAnimation,
+        child: FadeTransition(
+          opacity: _fadeAnimation,
+          child: GestureDetector(
+            onTap: () {
+              widget.onTap();
+              _controller.reverse().then((_) => widget.onDismissed());
+            },
+            child: Material(
+              color: Colors.transparent,
+              child: Container(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 16,
+                  vertical: 12,
+                ),
+                decoration: BoxDecoration(
+                  color: theme.colorScheme.surface.withOpacity(0.95),
+                  borderRadius: BorderRadius.circular(16),
+                  boxShadow: [
+                    BoxShadow(
+                      color: Colors.greenAccent.withOpacity(0.5),
+                      blurRadius: 10,
+                      spreadRadius: 1,
+                    ),
+                  ],
+                ),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      widget.message,
+                      style: theme.textTheme.bodyLarge?.copyWith(
+                        color: Colors.white,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                    const SizedBox(height: 8),
+                    ValueListenableBuilder<double>(
+                      valueListenable: _progress,
+                      builder: (context, value, _) {
+                        return ClipRRect(
+                          borderRadius: BorderRadius.circular(4),
+                          child: LinearProgressIndicator(
+                            value: value,
+                            minHeight: 4,
+                            backgroundColor: Colors.white10,
+                            valueColor: AlwaysStoppedAnimation(
+                              theme.colorScheme.primary,
+                            ),
+                          ),
+                        );
+                      },
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/toast.dart
+++ b/lib/toast.dart
@@ -110,7 +110,7 @@ class _ToastWidgetState extends State<_ToastWidget>
     final theme = Theme.of(context);
 
     return Positioned(
-      bottom: 50,
+      top: 50,
       left: 20,
       right: 20,
       child: SlideTransition(
@@ -144,12 +144,20 @@ class _ToastWidgetState extends State<_ToastWidget>
                   mainAxisSize: MainAxisSize.min,
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    Text(
-                      widget.message,
-                      style: theme.textTheme.bodyLarge?.copyWith(
-                        color: Colors.white,
-                        fontWeight: FontWeight.bold,
-                      ),
+                    Row(
+                      children: [
+                        const Icon(Icons.flash_on, color: Colors.amber),
+                        const SizedBox(width: 8),
+                        Expanded(
+                          child: Text(
+                            widget.message,
+                            style: theme.textTheme.bodyLarge?.copyWith(
+                              color: Colors.white,
+                              fontWeight: FontWeight.bold,
+                            ),
+                          ),
+                        ),
+                      ],
                     ),
                     const SizedBox(height: 8),
                     ValueListenableBuilder<double>(

--- a/lib/widgets/pending_deposit_item.dart
+++ b/lib/widgets/pending_deposit_item.dart
@@ -3,7 +3,7 @@ import 'package:carbine/multimint.dart';
 import 'package:carbine/utils.dart';
 
 class PendingDepositItem extends StatelessWidget {
-  final DepositEvent event;
+  final DepositEventKind event;
 
   const PendingDepositItem({super.key, required this.event});
 
@@ -12,7 +12,7 @@ class PendingDepositItem extends StatelessWidget {
     String msg;
     BigInt amount;
 
-    switch (event.eventKind) {
+    switch (event) {
       case DepositEventKind_Mempool(field0: final e):
         msg = 'Tx in mempool';
         amount = e.amount;

--- a/rust/carbine_fedimint/src/frb_generated.rs
+++ b/rust/carbine_fedimint/src/frb_generated.rs
@@ -41,7 +41,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.9.0";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -381752716;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 1337892317;
 
 // Section: executor
 
@@ -49,201 +49,6 @@ flutter_rust_bridge::frb_generated_default_handler!();
 
 // Section: wire_funcs
 
-fn wire__crate__multimint__DepositEvent_auto_accessor_get_event_kind_impl(
-    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
-    rust_vec_len_: i32,
-    data_len_: i32,
-) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::SseCodec, _>(
-        flutter_rust_bridge::for_generated::TaskInfo {
-            debug_name: "DepositEvent_auto_accessor_get_event_kind",
-            port: None,
-            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
-        },
-        move || {
-            let message = unsafe {
-                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
-                    ptr_,
-                    rust_vec_len_,
-                    data_len_,
-                )
-            };
-            let mut deserializer =
-                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
-            let api_that = <RustOpaqueMoi<
-                flutter_rust_bridge::for_generated::RustAutoOpaqueInner<DepositEvent>,
-            >>::sse_decode(&mut deserializer);
-            deserializer.end();
-            transform_result_sse::<_, ()>((move || {
-                let mut api_that_guard = None;
-                let decode_indices_ =
-                    flutter_rust_bridge::for_generated::lockable_compute_decode_order(vec![
-                        flutter_rust_bridge::for_generated::LockableOrderInfo::new(
-                            &api_that, 0, false,
-                        ),
-                    ]);
-                for i in decode_indices_ {
-                    match i {
-                        0 => api_that_guard = Some(api_that.lockable_decode_sync_ref()),
-                        _ => unreachable!(),
-                    }
-                }
-                let api_that_guard = api_that_guard.unwrap();
-                let output_ok = Result::<_, ()>::Ok(api_that_guard.event_kind.clone())?;
-                Ok(output_ok)
-            })())
-        },
-    )
-}
-fn wire__crate__multimint__DepositEvent_auto_accessor_get_federation_id_impl(
-    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
-    rust_vec_len_: i32,
-    data_len_: i32,
-) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::SseCodec, _>(
-        flutter_rust_bridge::for_generated::TaskInfo {
-            debug_name: "DepositEvent_auto_accessor_get_federation_id",
-            port: None,
-            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
-        },
-        move || {
-            let message = unsafe {
-                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
-                    ptr_,
-                    rust_vec_len_,
-                    data_len_,
-                )
-            };
-            let mut deserializer =
-                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
-            let api_that = <RustOpaqueMoi<
-                flutter_rust_bridge::for_generated::RustAutoOpaqueInner<DepositEvent>,
-            >>::sse_decode(&mut deserializer);
-            deserializer.end();
-            transform_result_sse::<_, ()>((move || {
-                let mut api_that_guard = None;
-                let decode_indices_ =
-                    flutter_rust_bridge::for_generated::lockable_compute_decode_order(vec![
-                        flutter_rust_bridge::for_generated::LockableOrderInfo::new(
-                            &api_that, 0, false,
-                        ),
-                    ]);
-                for i in decode_indices_ {
-                    match i {
-                        0 => api_that_guard = Some(api_that.lockable_decode_sync_ref()),
-                        _ => unreachable!(),
-                    }
-                }
-                let api_that_guard = api_that_guard.unwrap();
-                let output_ok = Result::<_, ()>::Ok(api_that_guard.federation_id.clone())?;
-                Ok(output_ok)
-            })())
-        },
-    )
-}
-fn wire__crate__multimint__DepositEvent_auto_accessor_set_event_kind_impl(
-    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
-    rust_vec_len_: i32,
-    data_len_: i32,
-) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::SseCodec, _>(
-        flutter_rust_bridge::for_generated::TaskInfo {
-            debug_name: "DepositEvent_auto_accessor_set_event_kind",
-            port: None,
-            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
-        },
-        move || {
-            let message = unsafe {
-                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
-                    ptr_,
-                    rust_vec_len_,
-                    data_len_,
-                )
-            };
-            let mut deserializer =
-                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
-            let api_that = <RustOpaqueMoi<
-                flutter_rust_bridge::for_generated::RustAutoOpaqueInner<DepositEvent>,
-            >>::sse_decode(&mut deserializer);
-            let api_event_kind =
-                <crate::multimint::DepositEventKind>::sse_decode(&mut deserializer);
-            deserializer.end();
-            transform_result_sse::<_, ()>((move || {
-                let mut api_that_guard = None;
-                let decode_indices_ =
-                    flutter_rust_bridge::for_generated::lockable_compute_decode_order(vec![
-                        flutter_rust_bridge::for_generated::LockableOrderInfo::new(
-                            &api_that, 0, true,
-                        ),
-                    ]);
-                for i in decode_indices_ {
-                    match i {
-                        0 => api_that_guard = Some(api_that.lockable_decode_sync_ref_mut()),
-                        _ => unreachable!(),
-                    }
-                }
-                let mut api_that_guard = api_that_guard.unwrap();
-                let output_ok = Result::<_, ()>::Ok({
-                    {
-                        api_that_guard.event_kind = api_event_kind;
-                    };
-                })?;
-                Ok(output_ok)
-            })())
-        },
-    )
-}
-fn wire__crate__multimint__DepositEvent_auto_accessor_set_federation_id_impl(
-    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
-    rust_vec_len_: i32,
-    data_len_: i32,
-) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::SseCodec, _>(
-        flutter_rust_bridge::for_generated::TaskInfo {
-            debug_name: "DepositEvent_auto_accessor_set_federation_id",
-            port: None,
-            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
-        },
-        move || {
-            let message = unsafe {
-                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
-                    ptr_,
-                    rust_vec_len_,
-                    data_len_,
-                )
-            };
-            let mut deserializer =
-                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
-            let api_that = <RustOpaqueMoi<
-                flutter_rust_bridge::for_generated::RustAutoOpaqueInner<DepositEvent>,
-            >>::sse_decode(&mut deserializer);
-            let api_federation_id = <FederationId>::sse_decode(&mut deserializer);
-            deserializer.end();
-            transform_result_sse::<_, ()>((move || {
-                let mut api_that_guard = None;
-                let decode_indices_ =
-                    flutter_rust_bridge::for_generated::lockable_compute_decode_order(vec![
-                        flutter_rust_bridge::for_generated::LockableOrderInfo::new(
-                            &api_that, 0, true,
-                        ),
-                    ]);
-                for i in decode_indices_ {
-                    match i {
-                        0 => api_that_guard = Some(api_that.lockable_decode_sync_ref_mut()),
-                        _ => unreachable!(),
-                    }
-                }
-                let mut api_that_guard = api_that_guard.unwrap();
-                let output_ok = Result::<_, ()>::Ok({
-                    {
-                        api_that_guard.federation_id = api_federation_id;
-                    };
-                })?;
-                Ok(output_ok)
-            })())
-        },
-    )
-}
 fn wire__crate__db__FederationConfig_auto_accessor_get_client_config_impl(
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
     rust_vec_len_: i32,
@@ -1110,6 +915,201 @@ fn wire__crate__multimint__FederationSelector_auto_accessor_set_network_impl(
                 let output_ok = Result::<_, ()>::Ok({
                     {
                         api_that_guard.network = api_network;
+                    };
+                })?;
+                Ok(output_ok)
+            })())
+        },
+    )
+}
+fn wire__crate__multimint__MultimintEvent_auto_accessor_get_event_kind_impl(
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::SseCodec, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "MultimintEvent_auto_accessor_get_event_kind",
+            port: None,
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_that = <RustOpaqueMoi<
+                flutter_rust_bridge::for_generated::RustAutoOpaqueInner<MultimintEvent>,
+            >>::sse_decode(&mut deserializer);
+            deserializer.end();
+            transform_result_sse::<_, ()>((move || {
+                let mut api_that_guard = None;
+                let decode_indices_ =
+                    flutter_rust_bridge::for_generated::lockable_compute_decode_order(vec![
+                        flutter_rust_bridge::for_generated::LockableOrderInfo::new(
+                            &api_that, 0, false,
+                        ),
+                    ]);
+                for i in decode_indices_ {
+                    match i {
+                        0 => api_that_guard = Some(api_that.lockable_decode_sync_ref()),
+                        _ => unreachable!(),
+                    }
+                }
+                let api_that_guard = api_that_guard.unwrap();
+                let output_ok = Result::<_, ()>::Ok(api_that_guard.event_kind.clone())?;
+                Ok(output_ok)
+            })())
+        },
+    )
+}
+fn wire__crate__multimint__MultimintEvent_auto_accessor_get_federation_id_impl(
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::SseCodec, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "MultimintEvent_auto_accessor_get_federation_id",
+            port: None,
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_that = <RustOpaqueMoi<
+                flutter_rust_bridge::for_generated::RustAutoOpaqueInner<MultimintEvent>,
+            >>::sse_decode(&mut deserializer);
+            deserializer.end();
+            transform_result_sse::<_, ()>((move || {
+                let mut api_that_guard = None;
+                let decode_indices_ =
+                    flutter_rust_bridge::for_generated::lockable_compute_decode_order(vec![
+                        flutter_rust_bridge::for_generated::LockableOrderInfo::new(
+                            &api_that, 0, false,
+                        ),
+                    ]);
+                for i in decode_indices_ {
+                    match i {
+                        0 => api_that_guard = Some(api_that.lockable_decode_sync_ref()),
+                        _ => unreachable!(),
+                    }
+                }
+                let api_that_guard = api_that_guard.unwrap();
+                let output_ok = Result::<_, ()>::Ok(api_that_guard.federation_id.clone())?;
+                Ok(output_ok)
+            })())
+        },
+    )
+}
+fn wire__crate__multimint__MultimintEvent_auto_accessor_set_event_kind_impl(
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::SseCodec, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "MultimintEvent_auto_accessor_set_event_kind",
+            port: None,
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_that = <RustOpaqueMoi<
+                flutter_rust_bridge::for_generated::RustAutoOpaqueInner<MultimintEvent>,
+            >>::sse_decode(&mut deserializer);
+            let api_event_kind =
+                <crate::multimint::MultimintEventKind>::sse_decode(&mut deserializer);
+            deserializer.end();
+            transform_result_sse::<_, ()>((move || {
+                let mut api_that_guard = None;
+                let decode_indices_ =
+                    flutter_rust_bridge::for_generated::lockable_compute_decode_order(vec![
+                        flutter_rust_bridge::for_generated::LockableOrderInfo::new(
+                            &api_that, 0, true,
+                        ),
+                    ]);
+                for i in decode_indices_ {
+                    match i {
+                        0 => api_that_guard = Some(api_that.lockable_decode_sync_ref_mut()),
+                        _ => unreachable!(),
+                    }
+                }
+                let mut api_that_guard = api_that_guard.unwrap();
+                let output_ok = Result::<_, ()>::Ok({
+                    {
+                        api_that_guard.event_kind = api_event_kind;
+                    };
+                })?;
+                Ok(output_ok)
+            })())
+        },
+    )
+}
+fn wire__crate__multimint__MultimintEvent_auto_accessor_set_federation_id_impl(
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::SseCodec, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "MultimintEvent_auto_accessor_set_federation_id",
+            port: None,
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_that = <RustOpaqueMoi<
+                flutter_rust_bridge::for_generated::RustAutoOpaqueInner<MultimintEvent>,
+            >>::sse_decode(&mut deserializer);
+            let api_federation_id = <FederationId>::sse_decode(&mut deserializer);
+            deserializer.end();
+            transform_result_sse::<_, ()>((move || {
+                let mut api_that_guard = None;
+                let decode_indices_ =
+                    flutter_rust_bridge::for_generated::lockable_compute_decode_order(vec![
+                        flutter_rust_bridge::for_generated::LockableOrderInfo::new(
+                            &api_that, 0, true,
+                        ),
+                    ]);
+                for i in decode_indices_ {
+                    match i {
+                        0 => api_that_guard = Some(api_that.lockable_decode_sync_ref_mut()),
+                        _ => unreachable!(),
+                    }
+                }
+                let mut api_that_guard = api_that_guard.unwrap();
+                let output_ok = Result::<_, ()>::Ok({
+                    {
+                        api_that_guard.federation_id = api_federation_id;
                     };
                 })?;
                 Ok(output_ok)
@@ -2717,13 +2717,79 @@ fn wire__crate__multimint__Multimint_subscribe_deposits_impl(
     rust_vec_len_: i32,
     data_len_: i32,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec,_,_,_>(flutter_rust_bridge::for_generated::TaskInfo{ debug_name: "Multimint_subscribe_deposits", port: Some(port_), mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal }, move || { 
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec, _, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "Multimint_subscribe_deposits",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_that = <RustOpaqueMoi<
+                flutter_rust_bridge::for_generated::RustAutoOpaqueInner<Multimint>,
+            >>::sse_decode(&mut deserializer);
+            let api_federation_id = <FederationId>::sse_decode(&mut deserializer);
+            let api_sink = <StreamSink<
+                crate::multimint::DepositEventKind,
+                flutter_rust_bridge::for_generated::SseCodec,
+            >>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| async move {
+                transform_result_sse::<_, ()>(
+                    (move || async move {
+                        let mut api_that_guard = None;
+                        let decode_indices_ =
+                            flutter_rust_bridge::for_generated::lockable_compute_decode_order(
+                                vec![flutter_rust_bridge::for_generated::LockableOrderInfo::new(
+                                    &api_that, 0, false,
+                                )],
+                            );
+                        for i in decode_indices_ {
+                            match i {
+                                0 => {
+                                    api_that_guard =
+                                        Some(api_that.lockable_decode_async_ref().await)
+                                }
+                                _ => unreachable!(),
+                            }
+                        }
+                        let api_that_guard = api_that_guard.unwrap();
+                        let output_ok = Result::<_, ()>::Ok({
+                            crate::multimint::Multimint::subscribe_deposits(
+                                &*api_that_guard,
+                                api_federation_id,
+                                api_sink,
+                            )
+                            .await;
+                        })?;
+                        Ok(output_ok)
+                    })()
+                    .await,
+                )
+            }
+        },
+    )
+}
+fn wire__crate__multimint__Multimint_subscribe_multimint_events_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec,_,_,_>(flutter_rust_bridge::for_generated::TaskInfo{ debug_name: "Multimint_subscribe_multimint_events", port: Some(port_), mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal }, move || { 
             let message = unsafe { flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(ptr_, rust_vec_len_, data_len_) };
             let mut deserializer = flutter_rust_bridge::for_generated::SseDeserializer::new(message);
             let api_that = <RustOpaqueMoi<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<Multimint>>>::sse_decode(&mut deserializer);
-let api_federation_id = <FederationId>::sse_decode(&mut deserializer);
-let api_sink = <StreamSink<DepositEvent,flutter_rust_bridge::for_generated::SseCodec>>::sse_decode(&mut deserializer);deserializer.end(); move |context| async move {
-                    transform_result_sse::<_, flutter_rust_bridge::for_generated::anyhow::Error>((move || async move {
+let api_sink = <StreamSink<MultimintEvent,flutter_rust_bridge::for_generated::SseCodec>>::sse_decode(&mut deserializer);deserializer.end(); move |context| async move {
+                    transform_result_sse::<_, ()>((move || async move {
                         let mut api_that_guard = None;
 let decode_indices_ = flutter_rust_bridge::for_generated::lockable_compute_decode_order(vec![flutter_rust_bridge::for_generated::LockableOrderInfo::new(&api_that, 0, false)]);
         for i in decode_indices_ {
@@ -2733,7 +2799,7 @@ let decode_indices_ = flutter_rust_bridge::for_generated::lockable_compute_decod
             }
         }
         let api_that_guard = api_that_guard.unwrap();
- let output_ok = crate::multimint::Multimint::subscribe_deposits(&*api_that_guard, api_federation_id, api_sink).await?;   Ok(output_ok)
+ let output_ok = Result::<_,()>::Ok({ crate::multimint::Multimint::subscribe_multimint_events(&*api_that_guard, api_sink).await; })?;   Ok(output_ok)
                     })().await)
                 } })
 }
@@ -4283,6 +4349,44 @@ fn wire__crate__create_new_multimint_impl(
         },
     )
 }
+fn wire__crate__federation_id_to_string_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec, _, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "federation_id_to_string",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_federation_id = <FederationId>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| async move {
+                transform_result_sse::<_, ()>(
+                    (move || async move {
+                        let output_ok = Result::<_, ()>::Ok(
+                            crate::federation_id_to_string(api_federation_id).await,
+                        )?;
+                        Ok(output_ok)
+                    })()
+                    .await,
+                )
+            }
+        },
+    )
+}
 fn wire__crate__federations_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
@@ -5245,13 +5349,54 @@ fn wire__crate__subscribe_deposits_impl(
     rust_vec_len_: i32,
     data_len_: i32,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec,_,_,_>(flutter_rust_bridge::for_generated::TaskInfo{ debug_name: "subscribe_deposits", port: Some(port_), mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal }, move || { 
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec, _, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "subscribe_deposits",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_sink = <StreamSink<
+                crate::multimint::DepositEventKind,
+                flutter_rust_bridge::for_generated::SseCodec,
+            >>::sse_decode(&mut deserializer);
+            let api_federation_id = <FederationId>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| async move {
+                transform_result_sse::<_, ()>(
+                    (move || async move {
+                        let output_ok = Result::<_, ()>::Ok({
+                            crate::subscribe_deposits(api_sink, api_federation_id).await;
+                        })?;
+                        Ok(output_ok)
+                    })()
+                    .await,
+                )
+            }
+        },
+    )
+}
+fn wire__crate__subscribe_multimint_events_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec,_,_,_>(flutter_rust_bridge::for_generated::TaskInfo{ debug_name: "subscribe_multimint_events", port: Some(port_), mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal }, move || { 
             let message = unsafe { flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(ptr_, rust_vec_len_, data_len_) };
             let mut deserializer = flutter_rust_bridge::for_generated::SseDeserializer::new(message);
-            let api_sink = <StreamSink<DepositEvent,flutter_rust_bridge::for_generated::SseCodec>>::sse_decode(&mut deserializer);
-let api_federation_id = <FederationId>::sse_decode(&mut deserializer);deserializer.end(); move |context| async move {
-                    transform_result_sse::<_, flutter_rust_bridge::for_generated::anyhow::Error>((move || async move {
-                         let output_ok = crate::subscribe_deposits(api_sink, api_federation_id).await?;   Ok(output_ok)
+            let api_sink = <StreamSink<MultimintEvent,flutter_rust_bridge::for_generated::SseCodec>>::sse_decode(&mut deserializer);deserializer.end(); move |context| async move {
+                    transform_result_sse::<_, ()>((move || async move {
+                         let output_ok = Result::<_,()>::Ok({ crate::subscribe_multimint_events(api_sink).await; })?;   Ok(output_ok)
                     })().await)
                 } })
 }
@@ -5449,9 +5594,6 @@ flutter_rust_bridge::frb_generated_moi_arc_impl_value!(
     flutter_rust_bridge::for_generated::RustAutoOpaqueInner<Database>
 );
 flutter_rust_bridge::frb_generated_moi_arc_impl_value!(
-    flutter_rust_bridge::for_generated::RustAutoOpaqueInner<DepositEvent>
-);
-flutter_rust_bridge::frb_generated_moi_arc_impl_value!(
     flutter_rust_bridge::for_generated::RustAutoOpaqueInner<FederationConfig>
 );
 flutter_rust_bridge::frb_generated_moi_arc_impl_value!(
@@ -5471,6 +5613,9 @@ flutter_rust_bridge::frb_generated_moi_arc_impl_value!(
 );
 flutter_rust_bridge::frb_generated_moi_arc_impl_value!(
     flutter_rust_bridge::for_generated::RustAutoOpaqueInner<Multimint>
+);
+flutter_rust_bridge::frb_generated_moi_arc_impl_value!(
+    flutter_rust_bridge::for_generated::RustAutoOpaqueInner<MultimintEvent>
 );
 flutter_rust_bridge::frb_generated_moi_arc_impl_value!(
     flutter_rust_bridge::for_generated::RustAutoOpaqueInner<NostrClient>
@@ -5551,16 +5696,6 @@ impl SseDecode for Database {
     }
 }
 
-impl SseDecode for DepositEvent {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
-        let mut inner = <RustOpaqueMoi<
-            flutter_rust_bridge::for_generated::RustAutoOpaqueInner<DepositEvent>,
-        >>::sse_decode(deserializer);
-        return flutter_rust_bridge::for_generated::rust_auto_opaque_decode_owned(inner);
-    }
-}
-
 impl SseDecode for FederationConfig {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -5626,6 +5761,16 @@ impl SseDecode for Multimint {
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         let mut inner = <RustOpaqueMoi<
             flutter_rust_bridge::for_generated::RustAutoOpaqueInner<Multimint>,
+        >>::sse_decode(deserializer);
+        return flutter_rust_bridge::for_generated::rust_auto_opaque_decode_owned(inner);
+    }
+}
+
+impl SseDecode for MultimintEvent {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut inner = <RustOpaqueMoi<
+            flutter_rust_bridge::for_generated::RustAutoOpaqueInner<MultimintEvent>,
         >>::sse_decode(deserializer);
         return flutter_rust_bridge::for_generated::rust_auto_opaque_decode_owned(inner);
     }
@@ -5740,16 +5885,6 @@ impl SseDecode
 }
 
 impl SseDecode
-    for RustOpaqueMoi<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<DepositEvent>>
-{
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
-        let mut inner = <usize>::sse_decode(deserializer);
-        return decode_rust_opaque_moi(inner);
-    }
-}
-
-impl SseDecode
     for RustOpaqueMoi<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<FederationConfig>>
 {
     // Codec=Sse (Serialization based), see doc to use other codecs
@@ -5824,6 +5959,16 @@ impl SseDecode
 }
 
 impl SseDecode
+    for RustOpaqueMoi<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<MultimintEvent>>
+{
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut inner = <usize>::sse_decode(deserializer);
+        return decode_rust_opaque_moi(inner);
+    }
+}
+
+impl SseDecode
     for RustOpaqueMoi<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<NostrClient>>
 {
     // Codec=Sse (Serialization based), see doc to use other codecs
@@ -5883,7 +6028,17 @@ impl SseDecode
     }
 }
 
-impl SseDecode for StreamSink<DepositEvent, flutter_rust_bridge::for_generated::SseCodec> {
+impl SseDecode for StreamSink<MultimintEvent, flutter_rust_bridge::for_generated::SseCodec> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut inner = <String>::sse_decode(deserializer);
+        return StreamSink::deserialize(inner);
+    }
+}
+
+impl SseDecode
+    for StreamSink<crate::multimint::DepositEventKind, flutter_rust_bridge::for_generated::SseCodec>
+{
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         let mut inner = <String>::sse_decode(deserializer);
@@ -5998,6 +6153,32 @@ impl SseDecode for crate::multimint::Guardian {
             name: var_name,
             version: var_version,
         };
+    }
+}
+
+impl SseDecode for crate::multimint::InvoicePaidEvent {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_amountMsats = <u64>::sse_decode(deserializer);
+        return crate::multimint::InvoicePaidEvent {
+            amount_msats: var_amountMsats,
+        };
+    }
+}
+
+impl SseDecode for crate::multimint::LightningEventKind {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut tag_ = <i32>::sse_decode(deserializer);
+        match tag_ {
+            0 => {
+                let mut var_field0 = <crate::multimint::InvoicePaidEvent>::sse_decode(deserializer);
+                return crate::multimint::LightningEventKind::InvoicePaid(var_field0);
+            }
+            _ => {
+                unimplemented!("");
+            }
+        }
     }
 }
 
@@ -6121,6 +6302,27 @@ impl SseDecode for crate::multimint::MultimintCreation {
     }
 }
 
+impl SseDecode for crate::multimint::MultimintEventKind {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut tag_ = <i32>::sse_decode(deserializer);
+        match tag_ {
+            0 => {
+                let mut var_field0 = <crate::multimint::DepositEventKind>::sse_decode(deserializer);
+                return crate::multimint::MultimintEventKind::Deposit(var_field0);
+            }
+            1 => {
+                let mut var_field0 =
+                    <crate::multimint::LightningEventKind>::sse_decode(deserializer);
+                return crate::multimint::MultimintEventKind::Lightning(var_field0);
+            }
+            _ => {
+                unimplemented!("");
+            }
+        }
+    }
+}
+
 impl SseDecode for crate::nostr::NWCConnectionInfo {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -6213,6 +6415,15 @@ impl SseDecode for (FederationSelector, crate::nostr::NWCConnectionInfo) {
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         let mut var_field0 = <FederationSelector>::sse_decode(deserializer);
         let mut var_field1 = <crate::nostr::NWCConnectionInfo>::sse_decode(deserializer);
+        return (var_field0, var_field1);
+    }
+}
+
+impl SseDecode for (FinalReceiveOperationState, u64) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_field0 = <FinalReceiveOperationState>::sse_decode(deserializer);
+        let mut var_field1 = <u64>::sse_decode(deserializer);
         return (var_field0, var_field1);
     }
 }
@@ -6426,69 +6637,77 @@ fn pde_ffi_dispatcher_primary_impl(
             rust_vec_len,
             data_len,
         ),
-        47 => {
+        47 => wire__crate__multimint__Multimint_subscribe_multimint_events_impl(
+            port,
+            ptr,
+            rust_vec_len,
+            data_len,
+        ),
+        48 => {
             wire__crate__multimint__Multimint_transactions_impl(port, ptr, rust_vec_len, data_len)
         }
-        48 => wire__crate__multimint__Multimint_wait_for_recovery_impl(
+        49 => wire__crate__multimint__Multimint_wait_for_recovery_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        49 => wire__crate__nostr__NostrClient_get_nwc_connection_info_impl(
+        50 => wire__crate__nostr__NostrClient_get_nwc_connection_info_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        50 => wire__crate__nostr__NostrClient_get_public_federations_impl(
+        51 => wire__crate__nostr__NostrClient_get_public_federations_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        51 => wire__crate__nostr__NostrClient_get_relays_impl(port, ptr, rust_vec_len, data_len),
-        52 => wire__crate__nostr__NostrClient_new_impl(port, ptr, rust_vec_len, data_len),
-        53 => wire__crate__nostr__NostrClient_set_nwc_connection_info_impl(
+        52 => wire__crate__nostr__NostrClient_get_relays_impl(port, ptr, rust_vec_len, data_len),
+        53 => wire__crate__nostr__NostrClient_new_impl(port, ptr, rust_vec_len, data_len),
+        54 => wire__crate__nostr__NostrClient_set_nwc_connection_info_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        68 => wire__crate__ack_seed_phrase_impl(port, ptr, rust_vec_len, data_len),
-        69 => wire__crate__allocate_deposit_address_impl(port, ptr, rust_vec_len, data_len),
-        70 => wire__crate__await_ecash_reissue_impl(port, ptr, rust_vec_len, data_len),
-        71 => wire__crate__await_ecash_send_impl(port, ptr, rust_vec_len, data_len),
-        72 => wire__crate__await_receive_impl(port, ptr, rust_vec_len, data_len),
-        73 => wire__crate__await_send_impl(port, ptr, rust_vec_len, data_len),
-        74 => wire__crate__balance_impl(port, ptr, rust_vec_len, data_len),
-        75 => wire__crate__create_multimint_from_words_impl(port, ptr, rust_vec_len, data_len),
-        76 => wire__crate__create_new_multimint_impl(port, ptr, rust_vec_len, data_len),
-        77 => wire__crate__federations_impl(port, ptr, rust_vec_len, data_len),
-        78 => wire__crate__get_federation_meta_impl(port, ptr, rust_vec_len, data_len),
-        79 => wire__crate__get_mnemonic_impl(port, ptr, rust_vec_len, data_len),
-        80 => wire__crate__get_nwc_connection_info_impl(port, ptr, rust_vec_len, data_len),
-        81 => wire__crate__get_relays_impl(port, ptr, rust_vec_len, data_len),
-        82 => wire__crate__has_seed_phrase_ack_impl(port, ptr, rust_vec_len, data_len),
-        83 => wire__crate__join_federation_impl(port, ptr, rust_vec_len, data_len),
-        84 => wire__crate__list_federations_from_nostr_impl(port, ptr, rust_vec_len, data_len),
-        85 => wire__crate__load_multimint_impl(port, ptr, rust_vec_len, data_len),
-        86 => wire__crate__monitor_deposit_address_impl(port, ptr, rust_vec_len, data_len),
-        87 => wire__crate__parse_ecash_impl(port, ptr, rust_vec_len, data_len),
-        88 => wire__crate__payment_preview_impl(port, ptr, rust_vec_len, data_len),
-        89 => wire__crate__receive_impl(port, ptr, rust_vec_len, data_len),
-        90 => wire__crate__refund_impl(port, ptr, rust_vec_len, data_len),
-        91 => wire__crate__reissue_ecash_impl(port, ptr, rust_vec_len, data_len),
-        92 => wire__crate__select_receive_gateway_impl(port, ptr, rust_vec_len, data_len),
-        93 => wire__crate__send_impl(port, ptr, rust_vec_len, data_len),
-        94 => wire__crate__send_ecash_impl(port, ptr, rust_vec_len, data_len),
-        95 => wire__crate__send_lnaddress_impl(port, ptr, rust_vec_len, data_len),
-        96 => wire__crate__set_nwc_connection_info_impl(port, ptr, rust_vec_len, data_len),
-        97 => wire__crate__subscribe_deposits_impl(port, ptr, rust_vec_len, data_len),
-        98 => wire__crate__transactions_impl(port, ptr, rust_vec_len, data_len),
-        99 => wire__crate__wait_for_recovery_impl(port, ptr, rust_vec_len, data_len),
-        100 => wire__crate__wallet_exists_impl(port, ptr, rust_vec_len, data_len),
-        101 => wire__crate__word_list_impl(port, ptr, rust_vec_len, data_len),
+        69 => wire__crate__ack_seed_phrase_impl(port, ptr, rust_vec_len, data_len),
+        70 => wire__crate__allocate_deposit_address_impl(port, ptr, rust_vec_len, data_len),
+        71 => wire__crate__await_ecash_reissue_impl(port, ptr, rust_vec_len, data_len),
+        72 => wire__crate__await_ecash_send_impl(port, ptr, rust_vec_len, data_len),
+        73 => wire__crate__await_receive_impl(port, ptr, rust_vec_len, data_len),
+        74 => wire__crate__await_send_impl(port, ptr, rust_vec_len, data_len),
+        75 => wire__crate__balance_impl(port, ptr, rust_vec_len, data_len),
+        76 => wire__crate__create_multimint_from_words_impl(port, ptr, rust_vec_len, data_len),
+        77 => wire__crate__create_new_multimint_impl(port, ptr, rust_vec_len, data_len),
+        78 => wire__crate__federation_id_to_string_impl(port, ptr, rust_vec_len, data_len),
+        79 => wire__crate__federations_impl(port, ptr, rust_vec_len, data_len),
+        80 => wire__crate__get_federation_meta_impl(port, ptr, rust_vec_len, data_len),
+        81 => wire__crate__get_mnemonic_impl(port, ptr, rust_vec_len, data_len),
+        82 => wire__crate__get_nwc_connection_info_impl(port, ptr, rust_vec_len, data_len),
+        83 => wire__crate__get_relays_impl(port, ptr, rust_vec_len, data_len),
+        84 => wire__crate__has_seed_phrase_ack_impl(port, ptr, rust_vec_len, data_len),
+        85 => wire__crate__join_federation_impl(port, ptr, rust_vec_len, data_len),
+        86 => wire__crate__list_federations_from_nostr_impl(port, ptr, rust_vec_len, data_len),
+        87 => wire__crate__load_multimint_impl(port, ptr, rust_vec_len, data_len),
+        88 => wire__crate__monitor_deposit_address_impl(port, ptr, rust_vec_len, data_len),
+        89 => wire__crate__parse_ecash_impl(port, ptr, rust_vec_len, data_len),
+        90 => wire__crate__payment_preview_impl(port, ptr, rust_vec_len, data_len),
+        91 => wire__crate__receive_impl(port, ptr, rust_vec_len, data_len),
+        92 => wire__crate__refund_impl(port, ptr, rust_vec_len, data_len),
+        93 => wire__crate__reissue_ecash_impl(port, ptr, rust_vec_len, data_len),
+        94 => wire__crate__select_receive_gateway_impl(port, ptr, rust_vec_len, data_len),
+        95 => wire__crate__send_impl(port, ptr, rust_vec_len, data_len),
+        96 => wire__crate__send_ecash_impl(port, ptr, rust_vec_len, data_len),
+        97 => wire__crate__send_lnaddress_impl(port, ptr, rust_vec_len, data_len),
+        98 => wire__crate__set_nwc_connection_info_impl(port, ptr, rust_vec_len, data_len),
+        99 => wire__crate__subscribe_deposits_impl(port, ptr, rust_vec_len, data_len),
+        100 => wire__crate__subscribe_multimint_events_impl(port, ptr, rust_vec_len, data_len),
+        101 => wire__crate__transactions_impl(port, ptr, rust_vec_len, data_len),
+        102 => wire__crate__wait_for_recovery_impl(port, ptr, rust_vec_len, data_len),
+        103 => wire__crate__wallet_exists_impl(port, ptr, rust_vec_len, data_len),
+        104 => wire__crate__word_list_impl(port, ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }
@@ -6501,182 +6720,182 @@ fn pde_ffi_dispatcher_sync_impl(
 ) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
     // Codec=Pde (Serialization + dispatch), see doc to use other codecs
     match func_id {
-        1 => wire__crate__multimint__DepositEvent_auto_accessor_get_event_kind_impl(
+        1 => wire__crate__db__FederationConfig_auto_accessor_get_client_config_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        2 => wire__crate__multimint__DepositEvent_auto_accessor_get_federation_id_impl(
+        2 => wire__crate__db__FederationConfig_auto_accessor_get_connector_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        3 => wire__crate__multimint__DepositEvent_auto_accessor_set_event_kind_impl(
+        3 => wire__crate__db__FederationConfig_auto_accessor_get_federation_name_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        4 => wire__crate__multimint__DepositEvent_auto_accessor_set_federation_id_impl(
+        4 => wire__crate__db__FederationConfig_auto_accessor_get_invite_code_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        5 => wire__crate__db__FederationConfig_auto_accessor_get_client_config_impl(
+        5 => wire__crate__db__FederationConfig_auto_accessor_get_network_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        6 => wire__crate__db__FederationConfig_auto_accessor_get_connector_impl(
+        6 => wire__crate__db__FederationConfig_auto_accessor_set_client_config_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        7 => wire__crate__db__FederationConfig_auto_accessor_get_federation_name_impl(
+        7 => wire__crate__db__FederationConfig_auto_accessor_set_connector_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        8 => wire__crate__db__FederationConfig_auto_accessor_get_invite_code_impl(
+        8 => wire__crate__db__FederationConfig_auto_accessor_set_federation_name_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        9 => wire__crate__db__FederationConfig_auto_accessor_get_network_impl(
+        9 => wire__crate__db__FederationConfig_auto_accessor_set_invite_code_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        10 => wire__crate__db__FederationConfig_auto_accessor_set_client_config_impl(
+        10 => wire__crate__db__FederationConfig_auto_accessor_set_network_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        11 => wire__crate__db__FederationConfig_auto_accessor_set_connector_impl(
+        11 => wire__crate__multimint__FederationSelector_auto_accessor_get_federation_id_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        12 => wire__crate__db__FederationConfig_auto_accessor_set_federation_name_impl(
+        12 => wire__crate__multimint__FederationSelector_auto_accessor_get_federation_name_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        13 => wire__crate__db__FederationConfig_auto_accessor_set_invite_code_impl(
+        13 => wire__crate__multimint__FederationSelector_auto_accessor_get_invite_code_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        14 => wire__crate__db__FederationConfig_auto_accessor_set_network_impl(
+        14 => wire__crate__multimint__FederationSelector_auto_accessor_get_network_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        15 => wire__crate__multimint__FederationSelector_auto_accessor_get_federation_id_impl(
+        15 => wire__crate__multimint__FederationSelector_auto_accessor_set_federation_id_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        16 => wire__crate__multimint__FederationSelector_auto_accessor_get_federation_name_impl(
+        16 => wire__crate__multimint__FederationSelector_auto_accessor_set_federation_name_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        17 => wire__crate__multimint__FederationSelector_auto_accessor_get_invite_code_impl(
+        17 => wire__crate__multimint__FederationSelector_auto_accessor_set_invite_code_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        18 => wire__crate__multimint__FederationSelector_auto_accessor_get_network_impl(
+        18 => wire__crate__multimint__FederationSelector_auto_accessor_set_network_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        19 => wire__crate__multimint__FederationSelector_auto_accessor_set_federation_id_impl(
+        19 => wire__crate__multimint__MultimintEvent_auto_accessor_get_event_kind_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        20 => wire__crate__multimint__FederationSelector_auto_accessor_set_federation_name_impl(
+        20 => wire__crate__multimint__MultimintEvent_auto_accessor_get_federation_id_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        21 => wire__crate__multimint__FederationSelector_auto_accessor_set_invite_code_impl(
+        21 => wire__crate__multimint__MultimintEvent_auto_accessor_set_event_kind_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        22 => wire__crate__multimint__FederationSelector_auto_accessor_set_network_impl(
+        22 => wire__crate__multimint__MultimintEvent_auto_accessor_set_federation_id_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        54 => wire__crate__nostr__PublicFederation_auto_accessor_get_about_impl(
+        55 => wire__crate__nostr__PublicFederation_auto_accessor_get_about_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        55 => wire__crate__nostr__PublicFederation_auto_accessor_get_federation_id_impl(
+        56 => wire__crate__nostr__PublicFederation_auto_accessor_get_federation_id_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        56 => wire__crate__nostr__PublicFederation_auto_accessor_get_federation_name_impl(
+        57 => wire__crate__nostr__PublicFederation_auto_accessor_get_federation_name_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        57 => wire__crate__nostr__PublicFederation_auto_accessor_get_invite_codes_impl(
+        58 => wire__crate__nostr__PublicFederation_auto_accessor_get_invite_codes_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        58 => wire__crate__nostr__PublicFederation_auto_accessor_get_modules_impl(
+        59 => wire__crate__nostr__PublicFederation_auto_accessor_get_modules_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        59 => wire__crate__nostr__PublicFederation_auto_accessor_get_network_impl(
+        60 => wire__crate__nostr__PublicFederation_auto_accessor_get_network_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        60 => wire__crate__nostr__PublicFederation_auto_accessor_get_picture_impl(
+        61 => wire__crate__nostr__PublicFederation_auto_accessor_get_picture_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        61 => wire__crate__nostr__PublicFederation_auto_accessor_set_about_impl(
+        62 => wire__crate__nostr__PublicFederation_auto_accessor_set_about_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        62 => wire__crate__nostr__PublicFederation_auto_accessor_set_federation_id_impl(
+        63 => wire__crate__nostr__PublicFederation_auto_accessor_set_federation_id_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        63 => wire__crate__nostr__PublicFederation_auto_accessor_set_federation_name_impl(
+        64 => wire__crate__nostr__PublicFederation_auto_accessor_set_federation_name_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        64 => wire__crate__nostr__PublicFederation_auto_accessor_set_invite_codes_impl(
+        65 => wire__crate__nostr__PublicFederation_auto_accessor_set_invite_codes_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        65 => wire__crate__nostr__PublicFederation_auto_accessor_set_modules_impl(
+        66 => wire__crate__nostr__PublicFederation_auto_accessor_set_modules_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        66 => wire__crate__nostr__PublicFederation_auto_accessor_set_network_impl(
+        67 => wire__crate__nostr__PublicFederation_auto_accessor_set_network_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        67 => wire__crate__nostr__PublicFederation_auto_accessor_set_picture_impl(
+        68 => wire__crate__nostr__PublicFederation_auto_accessor_set_picture_impl(
             ptr,
             rust_vec_len,
             data_len,
@@ -6758,21 +6977,6 @@ impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive for FrbWrapper<
 
 impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<Database>> for Database {
     fn into_into_dart(self) -> FrbWrapper<Database> {
-        self.into()
-    }
-}
-
-// Codec=Dco (DartCObject based), see doc to use other codecs
-impl flutter_rust_bridge::IntoDart for FrbWrapper<DepositEvent> {
-    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
-        flutter_rust_bridge::for_generated::rust_auto_opaque_encode::<_, MoiArc<_>>(self.0)
-            .into_dart()
-    }
-}
-impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive for FrbWrapper<DepositEvent> {}
-
-impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<DepositEvent>> for DepositEvent {
-    fn into_into_dart(self) -> FrbWrapper<DepositEvent> {
         self.into()
     }
 }
@@ -6891,6 +7095,21 @@ impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive for FrbWrapper<
 
 impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<Multimint>> for Multimint {
     fn into_into_dart(self) -> FrbWrapper<Multimint> {
+        self.into()
+    }
+}
+
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for FrbWrapper<MultimintEvent> {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        flutter_rust_bridge::for_generated::rust_auto_opaque_encode::<_, MoiArc<_>>(self.0)
+            .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive for FrbWrapper<MultimintEvent> {}
+
+impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<MultimintEvent>> for MultimintEvent {
+    fn into_into_dart(self) -> FrbWrapper<MultimintEvent> {
         self.into()
     }
 }
@@ -7127,6 +7346,47 @@ impl flutter_rust_bridge::IntoIntoDart<crate::multimint::Guardian> for crate::mu
     }
 }
 // Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::multimint::InvoicePaidEvent {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [self.amount_msats.into_into_dart().into_dart()].into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::multimint::InvoicePaidEvent
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::multimint::InvoicePaidEvent>
+    for crate::multimint::InvoicePaidEvent
+{
+    fn into_into_dart(self) -> crate::multimint::InvoicePaidEvent {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::multimint::LightningEventKind {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        match self {
+            crate::multimint::LightningEventKind::InvoicePaid(field0) => {
+                [0.into_dart(), field0.into_into_dart().into_dart()].into_dart()
+            }
+            _ => {
+                unimplemented!("");
+            }
+        }
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::multimint::LightningEventKind
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::multimint::LightningEventKind>
+    for crate::multimint::LightningEventKind
+{
+    fn into_into_dart(self) -> crate::multimint::LightningEventKind {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
 impl flutter_rust_bridge::IntoDart for crate::multimint::MempoolEvent {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
         [
@@ -7170,6 +7430,33 @@ impl flutter_rust_bridge::IntoIntoDart<crate::multimint::MultimintCreation>
     for crate::multimint::MultimintCreation
 {
     fn into_into_dart(self) -> crate::multimint::MultimintCreation {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::multimint::MultimintEventKind {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        match self {
+            crate::multimint::MultimintEventKind::Deposit(field0) => {
+                [0.into_dart(), field0.into_into_dart().into_dart()].into_dart()
+            }
+            crate::multimint::MultimintEventKind::Lightning(field0) => {
+                [1.into_dart(), field0.into_into_dart().into_dart()].into_dart()
+            }
+            _ => {
+                unimplemented!("");
+            }
+        }
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::multimint::MultimintEventKind
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::multimint::MultimintEventKind>
+    for crate::multimint::MultimintEventKind
+{
+    fn into_into_dart(self) -> crate::multimint::MultimintEventKind {
         self
     }
 }
@@ -7285,13 +7572,6 @@ impl SseEncode for Database {
     }
 }
 
-impl SseEncode for DepositEvent {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
-        <RustOpaqueMoi<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<DepositEvent>>>::sse_encode(flutter_rust_bridge::for_generated::rust_auto_opaque_encode::<_, MoiArc<_>>(self), serializer);
-    }
-}
-
 impl SseEncode for FederationConfig {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
@@ -7348,6 +7628,13 @@ impl SseEncode for Multimint {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         <RustOpaqueMoi<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<Multimint>>>::sse_encode(flutter_rust_bridge::for_generated::rust_auto_opaque_encode::<_, MoiArc<_>>(self), serializer);
+    }
+}
+
+impl SseEncode for MultimintEvent {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <RustOpaqueMoi<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<MultimintEvent>>>::sse_encode(flutter_rust_bridge::for_generated::rust_auto_opaque_encode::<_, MoiArc<_>>(self), serializer);
     }
 }
 
@@ -7452,17 +7739,6 @@ impl SseEncode
 }
 
 impl SseEncode
-    for RustOpaqueMoi<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<DepositEvent>>
-{
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
-        let (ptr, size) = self.sse_encode_raw();
-        <usize>::sse_encode(ptr, serializer);
-        <i32>::sse_encode(size, serializer);
-    }
-}
-
-impl SseEncode
     for RustOpaqueMoi<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<FederationConfig>>
 {
     // Codec=Sse (Serialization based), see doc to use other codecs
@@ -7544,6 +7820,17 @@ impl SseEncode
 }
 
 impl SseEncode
+    for RustOpaqueMoi<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<MultimintEvent>>
+{
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        let (ptr, size) = self.sse_encode_raw();
+        <usize>::sse_encode(ptr, serializer);
+        <i32>::sse_encode(size, serializer);
+    }
+}
+
+impl SseEncode
     for RustOpaqueMoi<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<NostrClient>>
 {
     // Codec=Sse (Serialization based), see doc to use other codecs
@@ -7609,7 +7896,16 @@ impl SseEncode
     }
 }
 
-impl SseEncode for StreamSink<DepositEvent, flutter_rust_bridge::for_generated::SseCodec> {
+impl SseEncode for StreamSink<MultimintEvent, flutter_rust_bridge::for_generated::SseCodec> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        unimplemented!("")
+    }
+}
+
+impl SseEncode
+    for StreamSink<crate::multimint::DepositEventKind, flutter_rust_bridge::for_generated::SseCodec>
+{
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         unimplemented!("")
@@ -7697,6 +7993,28 @@ impl SseEncode for crate::multimint::Guardian {
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         <String>::sse_encode(self.name, serializer);
         <Option<String>>::sse_encode(self.version, serializer);
+    }
+}
+
+impl SseEncode for crate::multimint::InvoicePaidEvent {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <u64>::sse_encode(self.amount_msats, serializer);
+    }
+}
+
+impl SseEncode for crate::multimint::LightningEventKind {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        match self {
+            crate::multimint::LightningEventKind::InvoicePaid(field0) => {
+                <i32>::sse_encode(0, serializer);
+                <crate::multimint::InvoicePaidEvent>::sse_encode(field0, serializer);
+            }
+            _ => {
+                unimplemented!("");
+            }
+        }
     }
 }
 
@@ -7799,6 +8117,25 @@ impl SseEncode for crate::multimint::MultimintCreation {
     }
 }
 
+impl SseEncode for crate::multimint::MultimintEventKind {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        match self {
+            crate::multimint::MultimintEventKind::Deposit(field0) => {
+                <i32>::sse_encode(0, serializer);
+                <crate::multimint::DepositEventKind>::sse_encode(field0, serializer);
+            }
+            crate::multimint::MultimintEventKind::Lightning(field0) => {
+                <i32>::sse_encode(1, serializer);
+                <crate::multimint::LightningEventKind>::sse_encode(field0, serializer);
+            }
+            _ => {
+                unimplemented!("");
+            }
+        }
+    }
+}
+
 impl SseEncode for crate::nostr::NWCConnectionInfo {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
@@ -7872,6 +8209,14 @@ impl SseEncode for (FederationSelector, crate::nostr::NWCConnectionInfo) {
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         <FederationSelector>::sse_encode(self.0, serializer);
         <crate::nostr::NWCConnectionInfo>::sse_encode(self.1, serializer);
+    }
+}
+
+impl SseEncode for (FinalReceiveOperationState, u64) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <FinalReceiveOperationState>::sse_encode(self.0, serializer);
+        <u64>::sse_encode(self.1, serializer);
     }
 }
 
@@ -8068,20 +8413,6 @@ mod io {
     }
 
     #[unsafe(no_mangle)]
-    pub extern "C" fn frbgen_carbine_rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDepositEvent(
-        ptr: *const std::ffi::c_void,
-    ) {
-        MoiArc::<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<DepositEvent>>::increment_strong_count(ptr as _);
-    }
-
-    #[unsafe(no_mangle)]
-    pub extern "C" fn frbgen_carbine_rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDepositEvent(
-        ptr: *const std::ffi::c_void,
-    ) {
-        MoiArc::<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<DepositEvent>>::decrement_strong_count(ptr as _);
-    }
-
-    #[unsafe(no_mangle)]
     pub extern "C" fn frbgen_carbine_rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerFederationConfig(
         ptr: *const std::ffi::c_void,
     ) {
@@ -8177,6 +8508,20 @@ mod io {
         ptr: *const std::ffi::c_void,
     ) {
         MoiArc::<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<Multimint>>::decrement_strong_count(ptr as _);
+    }
+
+    #[unsafe(no_mangle)]
+    pub extern "C" fn frbgen_carbine_rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMultimintEvent(
+        ptr: *const std::ffi::c_void,
+    ) {
+        MoiArc::<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<MultimintEvent>>::increment_strong_count(ptr as _);
+    }
+
+    #[unsafe(no_mangle)]
+    pub extern "C" fn frbgen_carbine_rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMultimintEvent(
+        ptr: *const std::ffi::c_void,
+    ) {
+        MoiArc::<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<MultimintEvent>>::decrement_strong_count(ptr as _);
     }
 
     #[unsafe(no_mangle)]
@@ -8362,20 +8707,6 @@ mod web {
     }
 
     #[wasm_bindgen]
-    pub fn rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDepositEvent(
-        ptr: *const std::ffi::c_void,
-    ) {
-        MoiArc::<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<DepositEvent>>::increment_strong_count(ptr as _);
-    }
-
-    #[wasm_bindgen]
-    pub fn rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDepositEvent(
-        ptr: *const std::ffi::c_void,
-    ) {
-        MoiArc::<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<DepositEvent>>::decrement_strong_count(ptr as _);
-    }
-
-    #[wasm_bindgen]
     pub fn rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerFederationConfig(
         ptr: *const std::ffi::c_void,
     ) {
@@ -8471,6 +8802,20 @@ mod web {
         ptr: *const std::ffi::c_void,
     ) {
         MoiArc::<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<Multimint>>::decrement_strong_count(ptr as _);
+    }
+
+    #[wasm_bindgen]
+    pub fn rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMultimintEvent(
+        ptr: *const std::ffi::c_void,
+    ) {
+        MoiArc::<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<MultimintEvent>>::increment_strong_count(ptr as _);
+    }
+
+    #[wasm_bindgen]
+    pub fn rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMultimintEvent(
+        ptr: *const std::ffi::c_void,
+    ) {
+        MoiArc::<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<MultimintEvent>>::decrement_strong_count(ptr as _);
     }
 
     #[wasm_bindgen]

--- a/rust/carbine_fedimint/src/lib.rs
+++ b/rust/carbine_fedimint/src/lib.rs
@@ -10,7 +10,8 @@ use fedimint_core::config::ClientConfig;
 /* AUTO INJECTED BY flutter_rust_bridge. This line may not be accurate, and you can change it according to your needs. */
 use flutter_rust_bridge::frb;
 use multimint::{
-    FederationMeta, FederationSelector, Multimint, MultimintCreation, PaymentPreview, Transaction,
+    FederationMeta, FederationSelector, Multimint, MultimintCreation, MultimintEvent,
+    PaymentPreview, Transaction,
 };
 use nostr::{NWCConnectionInfo, NostrClient, PublicFederation};
 use tokio::sync::{OnceCell, RwLock};
@@ -33,7 +34,7 @@ use lightning_invoice::Bolt11Invoice;
 
 use crate::db::{FederationConfig, FederationConfigKey, FederationConfigKeyPrefix};
 use crate::frb_generated::StreamSink;
-use crate::multimint::DepositEvent;
+use crate::multimint::DepositEventKind;
 
 static MULTIMINT: OnceCell<Multimint> = OnceCell::const_new();
 static DATABASE: OnceCell<Database> = OnceCell::const_new();
@@ -262,7 +263,7 @@ pub async fn await_send(
 pub async fn await_receive(
     federation_id: &FederationId,
     operation_id: OperationId,
-) -> anyhow::Result<FinalReceiveOperationState> {
+) -> anyhow::Result<(FinalReceiveOperationState, u64)> {
     let multimint = get_multimint().await;
     multimint.await_receive(federation_id, operation_id).await
 }
@@ -409,12 +410,9 @@ pub async fn word_list() -> Vec<String> {
 }
 
 #[frb]
-pub async fn subscribe_deposits(
-    sink: StreamSink<DepositEvent>,
-    federation_id: FederationId,
-) -> anyhow::Result<()> {
+pub async fn subscribe_deposits(sink: StreamSink<DepositEventKind>, federation_id: FederationId) {
     let multimint = get_multimint().await;
-    multimint.subscribe_deposits(federation_id, sink).await
+    multimint.subscribe_deposits(federation_id, sink).await;
 }
 
 #[frb]
@@ -456,4 +454,15 @@ pub async fn get_relays() -> Vec<String> {
     let nostr_client = get_nostr_client().await;
     let nostr = nostr_client.read().await;
     nostr.get_relays().await
+}
+
+#[frb]
+pub async fn subscribe_multimint_events(sink: StreamSink<MultimintEvent>) {
+    let multimint = get_multimint().await;
+    multimint.subscribe_multimint_events(sink).await
+}
+
+#[frb]
+pub async fn federation_id_to_string(federation_id: FederationId) -> String {
+    federation_id.to_string()
 }

--- a/rust/carbine_fedimint/src/multimint.rs
+++ b/rust/carbine_fedimint/src/multimint.rs
@@ -11,8 +11,9 @@ use bitcoin::key::rand::{seq::SliceRandom, thread_rng};
 use fedimint_api_client::api::net::Connector;
 use fedimint_bip39::{Bip39RootSecretStrategy, Language, Mnemonic};
 use fedimint_client::{
-    db::ChronologicalOperationLogKey, module_init::ClientModuleInitRegistry,
-    secret::RootSecretStrategy, Client, ClientHandleArc, OperationId,
+    db::ChronologicalOperationLogKey, module::oplog::OperationLogEntry,
+    module_init::ClientModuleInitRegistry, secret::RootSecretStrategy, Client, ClientHandleArc,
+    OperationId,
 };
 use fedimint_core::{
     config::{ClientConfig, FederationId},
@@ -94,7 +95,7 @@ pub struct Multimint {
     clients: Arc<RwLock<BTreeMap<FederationId, ClientHandleArc>>>,
     task_group: TaskGroup,
     pegin_address_monitor_tx: UnboundedSender<(FederationId, TweakIdx)>,
-    event_bus: EventBus<DepositEvent>,
+    event_bus: EventBus<MultimintEvent>,
 }
 
 #[derive(Debug, Serialize)]
@@ -167,9 +168,25 @@ pub enum DepositEventKind {
 }
 
 #[derive(Clone, Eq, PartialEq, Serialize, Debug)]
-pub struct DepositEvent {
+pub struct InvoicePaidEvent {
+    pub amount_msats: u64,
+}
+
+#[derive(Clone, Eq, PartialEq, Serialize, Debug)]
+pub enum LightningEventKind {
+    InvoicePaid(InvoicePaidEvent),
+}
+
+#[derive(Clone, Eq, PartialEq, Serialize, Debug)]
+pub enum MultimintEventKind {
+    Deposit(DepositEventKind),
+    Lightning(LightningEventKind),
+}
+
+#[derive(Clone, Eq, PartialEq, Serialize, Debug)]
+pub struct MultimintEvent {
     pub federation_id: FederationId,
-    pub event_kind: DepositEventKind,
+    pub event_kind: MultimintEventKind,
 }
 
 impl Multimint {
@@ -332,7 +349,7 @@ impl Multimint {
         federation_id: FederationId,
         client: ClientHandleArc,
         tweak_idx: TweakIdx,
-        event_bus: EventBus<DepositEvent>,
+        event_bus: EventBus<MultimintEvent>,
     ) -> anyhow::Result<()> {
         let wallet_module = client.get_first_module::<WalletClientModule>()?;
 
@@ -354,12 +371,14 @@ impl Multimint {
                     btc_deposited,
                     btc_out_point,
                 } => {
-                    let deposit_event = DepositEvent {
+                    let deposit_event = MultimintEvent {
                         federation_id,
-                        event_kind: DepositEventKind::Mempool(MempoolEvent {
-                            amount: Amount::from_sats(btc_deposited.to_sat()).msats,
-                            txid: btc_out_point.txid.to_string(),
-                        }),
+                        event_kind: MultimintEventKind::Deposit(DepositEventKind::Mempool(
+                            MempoolEvent {
+                                amount: Amount::from_sats(btc_deposited.to_sat()).msats,
+                                txid: btc_out_point.txid.to_string(),
+                            },
+                        )),
                     };
 
                     event_bus.publish(deposit_event).await;
@@ -417,14 +436,16 @@ impl Multimint {
 
                         let needed = tx_height.saturating_sub(consensus_height);
 
-                        let deposit_event = DepositEvent {
+                        let deposit_event = MultimintEvent {
                             federation_id,
-                            event_kind: DepositEventKind::AwaitingConfs(AwaitingConfsEvent {
-                                amount: Amount::from_sats(btc_deposited.to_sat()).msats,
-                                txid: btc_out_point.txid.to_string(),
-                                block_height: tx_height,
-                                needed,
-                            }),
+                            event_kind: MultimintEventKind::Deposit(
+                                DepositEventKind::AwaitingConfs(AwaitingConfsEvent {
+                                    amount: Amount::from_sats(btc_deposited.to_sat()).msats,
+                                    txid: btc_out_point.txid.to_string(),
+                                    block_height: tx_height,
+                                    needed,
+                                }),
+                            ),
                         };
 
                         event_bus.publish(deposit_event).await;
@@ -442,12 +463,14 @@ impl Multimint {
                     btc_deposited,
                     btc_out_point,
                 } => {
-                    let deposit_event = DepositEvent {
+                    let deposit_event = MultimintEvent {
                         federation_id,
-                        event_kind: DepositEventKind::Confirmed(ConfirmedEvent {
-                            amount: Amount::from_sats(btc_deposited.to_sat()).msats,
-                            txid: btc_out_point.txid.to_string(),
-                        }),
+                        event_kind: MultimintEventKind::Deposit(DepositEventKind::Confirmed(
+                            ConfirmedEvent {
+                                amount: Amount::from_sats(btc_deposited.to_sat()).msats,
+                                txid: btc_out_point.txid.to_string(),
+                            },
+                        )),
                     };
 
                     event_bus.publish(deposit_event).await;
@@ -456,12 +479,14 @@ impl Multimint {
                     btc_deposited,
                     btc_out_point,
                 } => {
-                    let deposit_event = DepositEvent {
+                    let deposit_event = MultimintEvent {
                         federation_id,
-                        event_kind: DepositEventKind::Claimed(ClaimedEvent {
-                            amount: Amount::from_sats(btc_deposited.to_sat()).msats,
-                            txid: btc_out_point.txid.to_string(),
-                        }),
+                        event_kind: MultimintEventKind::Deposit(DepositEventKind::Claimed(
+                            ClaimedEvent {
+                                amount: Amount::from_sats(btc_deposited.to_sat()).msats,
+                                txid: btc_out_point.txid.to_string(),
+                            },
+                        )),
                     };
 
                     event_bus.publish(deposit_event).await;
@@ -942,7 +967,18 @@ impl Multimint {
         self.task_group
             .spawn_cancellable("await receive", async move {
                 match self_copy.await_receive(&federation_id, operation_id).await {
-                    Ok(final_state) => println!("Receive completed: {final_state:?}"),
+                    Ok((final_state, amount_msats)) => {
+                        let lightning_event =
+                            LightningEventKind::InvoicePaid(InvoicePaidEvent { amount_msats });
+                        println!("Receive completed: {final_state:?}");
+                        self_copy
+                            .event_bus
+                            .publish(MultimintEvent {
+                                federation_id,
+                                event_kind: MultimintEventKind::Lightning(lightning_event),
+                            })
+                            .await;
+                    }
                     Err(e) => println!("Could not await receive {operation_id:?} {e:?}"),
                 }
             });
@@ -1266,7 +1302,7 @@ impl Multimint {
         &self,
         federation_id: &FederationId,
         operation_id: OperationId,
-    ) -> anyhow::Result<FinalReceiveOperationState> {
+    ) -> anyhow::Result<(FinalReceiveOperationState, u64)> {
         let client = self
             .clients
             .read()
@@ -1274,18 +1310,18 @@ impl Multimint {
             .get(federation_id)
             .expect("No federation exists")
             .clone();
-        let receive_state = match Self::await_receive_lnv2(&client, operation_id).await {
+        let (receive_state, amount) = match Self::await_receive_lnv2(&client, operation_id).await {
             Ok(lnv2_final_state) => lnv2_final_state,
             Err(_) => Self::await_receive_lnv1(&client, operation_id).await?,
         };
 
-        Ok(receive_state)
+        Ok((receive_state, amount))
     }
 
     async fn await_receive_lnv2(
         client: &ClientHandleArc,
         operation_id: OperationId,
-    ) -> anyhow::Result<FinalReceiveOperationState> {
+    ) -> anyhow::Result<(FinalReceiveOperationState, u64)> {
         let lnv2 = client.get_first_module::<fedimint_lnv2_client::LightningClientModule>()?;
         let mut updates = lnv2
             .subscribe_receive_operation_state_updates(operation_id)
@@ -1306,13 +1342,31 @@ impl Multimint {
                 _ => {}
             }
         }
-        Ok(final_state)
+
+        let operation = client.operation_log().get_operation(operation_id).await;
+        let amount = Self::get_lnv2_amount_from_meta(operation);
+        Ok((final_state, amount))
+    }
+
+    fn get_lnv2_amount_from_meta(op_log_val: Option<OperationLogEntry>) -> u64 {
+        let Some(op_log_val) = op_log_val else {
+            return 0;
+        };
+        let meta = op_log_val.meta::<LightningOperationMeta>();
+        match meta {
+            LightningOperationMeta::Receive(receive) => {
+                serde_json::from_value::<Amount>(receive.custom_meta)
+                    .expect("Could not deserialize amount")
+                    .msats
+            }
+            LightningOperationMeta::Send(send) => send.contract.amount.msats,
+        }
     }
 
     async fn await_receive_lnv1(
         client: &ClientHandleArc,
         operation_id: OperationId,
-    ) -> anyhow::Result<FinalReceiveOperationState> {
+    ) -> anyhow::Result<(FinalReceiveOperationState, u64)> {
         let lnv1 = client.get_first_module::<LightningClientModule>()?;
         let mut updates = lnv1.subscribe_ln_receive(operation_id).await?.into_stream();
         let mut final_state = FinalReceiveOperationState::Failure;
@@ -1325,7 +1379,32 @@ impl Multimint {
             }
         }
 
-        Ok(final_state)
+        let operation = client.operation_log().get_operation(operation_id).await;
+        let amount = Self::get_lnv1_amount_from_meta(operation);
+        Ok((final_state, amount))
+    }
+
+    fn get_lnv1_amount_from_meta(op_log_val: Option<OperationLogEntry>) -> u64 {
+        let Some(op_log_val) = op_log_val else {
+            return 0;
+        };
+
+        let meta = op_log_val.meta::<fedimint_ln_client::LightningOperationMeta>();
+        match meta.variant {
+            LightningOperationMetaVariant::Pay(send) => send
+                .invoice
+                .amount_milli_satoshis()
+                .expect("Cannot pay amountless invoice"),
+            LightningOperationMetaVariant::Receive { invoice, .. } => invoice
+                .amount_milli_satoshis()
+                .expect("Cannot receive amountless invoice"),
+            LightningOperationMetaVariant::RecurringPaymentReceive(recurring) => recurring
+                .invoice
+                .amount_milli_satoshis()
+                .expect("Cannot receive amountless invoice"),
+            // Claim is covered by send
+            _ => 0,
+        }
     }
 
     async fn lnv1_update_gateway_cache(&self, client: &ClientHandleArc) -> anyhow::Result<()> {
@@ -1833,19 +1912,29 @@ impl Multimint {
     pub async fn subscribe_deposits(
         &self,
         federation_id: FederationId,
-        sink: StreamSink<DepositEvent>,
-    ) -> anyhow::Result<()> {
+        sink: StreamSink<DepositEventKind>,
+    ) {
         let mut stream = self.event_bus.subscribe();
 
         while let Some(evt) = stream.next().await {
             if evt.federation_id == federation_id {
-                if sink.add(evt).is_err() {
-                    break;
+                if let MultimintEventKind::Deposit(deposit) = evt.event_kind {
+                    if sink.add(deposit).is_err() {
+                        break;
+                    }
                 }
             }
         }
+    }
 
-        Ok(())
+    pub async fn subscribe_multimint_events(&self, sink: StreamSink<MultimintEvent>) {
+        let mut stream = self.event_bus.subscribe();
+
+        while let Some(mm_event) = stream.next().await {
+            if sink.add(mm_event).is_err() {
+                break;
+            }
+        }
     }
 }
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/aece8ad3-a71f-448a-86d2-44310e022164)

Previously, the user would only get a notification that they received a Lightning payment if the `Request` widget was still open.

This PR changes this to add an "async lightning receive". A toast will show the user which federation received some sats. The balance on the dashboard will update if they have the dashboard screen up.

If the user clicks the toast, it will bring them to the appropriate federation's dashboard (regardless of their current screen).

To do this I needed to refactor some of the `DepositEvent` logic, so let's make sure to review that so that I don't break anything.