### PR TITLE
fix: wait for build to finish before changing scroll position

### DIFF
--- a/lib/widgets/transactions_list.dart
+++ b/lib/widgets/transactions_list.dart
@@ -91,9 +91,11 @@ class _TransactionsListState extends State<TransactionsList> {
       _hasMore = true;
       _lastTransaction = null;
       _isLoading = true;
-      if (_scrollController.hasClients) {
-        _scrollController.jumpTo(0);
-      }
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (_scrollController.hasClients) {
+          _scrollController.jumpTo(0);
+        }
+      });
       _loadTransactions();
     }
   }


### PR DESCRIPTION
If we don't schedule the scroll controller until after the build finishes, we get the following error

```
══╡ EXCEPTION CAUGHT BY WIDGET LIBRARY ╞════════════════════════════════════════════════════════════
The following assertion was thrown while dispatching notifications for
ScrollNotificationObserverState:
setState() or markNeedsBuild() called during build.
This AppBar widget cannot be marked as needing to build because the framework is already in the
process of building widgets. A widget can be marked as needing to be built during the build phase
only if one of its ancestors is currently building. This exception is allowed because the framework
builds parent widgets before children, which means a dirty descendant will always be built.
Otherwise, the framework might not visit this widget during this build phase.
The widget on which setState() or markNeedsBuild() was called was:
  AppBar
The widget which was currently being built when the offending call was made was:
  Expanded
```