### PR TITLE
feat: backup and recover invite code from Nostr

### DIFF
--- a/lib/create_wallet.dart
+++ b/lib/create_wallet.dart
@@ -39,7 +39,13 @@ class _CreateWalletState extends State<CreateWallet> {
       await createNewMultimint(path: widget.dir.path);
       if (mounted) {
         Navigator.of(context).pushReplacement(
-          MaterialPageRoute(builder: (_) => MyApp(initialFederations: [])),
+          MaterialPageRoute(
+            builder:
+                (_) => MyApp(
+                  initialFederations: [],
+                  recoverFederationInviteCodes: false,
+                ),
+          ),
         );
       }
     } catch (e) {
@@ -55,7 +61,13 @@ class _CreateWalletState extends State<CreateWallet> {
       await createMultimintFromWords(path: widget.dir.path, words: words);
       if (mounted) {
         Navigator.of(context).pushReplacement(
-          MaterialPageRoute(builder: (_) => MyApp(initialFederations: [])),
+          MaterialPageRoute(
+            builder:
+                (_) => MyApp(
+                  initialFederations: [],
+                  recoverFederationInviteCodes: true,
+                ),
+          ),
         );
       }
     } catch (e) {

--- a/lib/fed_preview.dart
+++ b/lib/fed_preview.dart
@@ -48,9 +48,15 @@ class _FederationPreviewState extends State<FederationPreview> {
           recover: false,
         );
         AppLogger.instance.info('Successfully joined federation');
+
         if (mounted) {
           Navigator.of(context).pop((fed, false));
         }
+
+        // backup the federation's invite codes as a replaceable event to Nostr
+        final newFeds = await federations();
+        final inviteCodes = newFeds.map((f) => f.$1.inviteCode).toList();
+        backupInviteCodes(inviteCodes: inviteCodes);
       } catch (e) {
         AppLogger.instance.error('Could not join federation $e');
         setState(() {

--- a/lib/frb_generated.dart
+++ b/lib/frb_generated.dart
@@ -66,7 +66,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.9.0';
 
   @override
-  int get rustContentHash => 1203720947;
+  int get rustContentHash => 864321999;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -356,11 +356,6 @@ abstract class RustLibApi extends BaseApi {
     required List<String> modules,
   });
 
-  Future<FederationSelector> crateMultimintMultimintWaitForRecovery({
-    required Multimint that,
-    required String inviteCode,
-  });
-
   Future<List<Utxo>> crateMultimintMultimintWalletSummary({
     required Multimint that,
     required String invite,
@@ -372,6 +367,15 @@ abstract class RustLibApi extends BaseApi {
     required String address,
     required BigInt amountSats,
     required PegOutFees pegOutFees,
+  });
+
+  Future<void> crateNostrNostrClientBackupInviteCodes({
+    required NostrClient that,
+    required List<String> inviteCodes,
+  });
+
+  Future<List<String>> crateNostrNostrClientGetBackupInviteCodes({
+    required NostrClient that,
   });
 
   Future<List<(FederationSelector, NWCConnectionInfo)>>
@@ -524,6 +528,8 @@ abstract class RustLibApi extends BaseApi {
     required OperationId operationId,
   });
 
+  Future<void> crateBackupInviteCodes({required List<String> inviteCodes});
+
   Future<BigInt> crateBalance({required FederationId federationId});
 
   Future<WithdrawFeesResponse> crateCalculateWithdrawFees({
@@ -544,6 +550,8 @@ abstract class RustLibApi extends BaseApi {
   });
 
   Future<List<(FederationSelector, bool)>> crateFederations();
+
+  Future<List<String>> crateGetBackupInviteCodes();
 
   Future<BigInt?> crateGetBtcPrice();
 
@@ -644,8 +652,6 @@ abstract class RustLibApi extends BaseApi {
     Uint8List? operationId,
     required List<String> modules,
   });
-
-  Future<FederationSelector> crateWaitForRecovery({required String inviteCode});
 
   Future<bool> crateWalletExists({required String path});
 
@@ -2985,45 +2991,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
-  Future<FederationSelector> crateMultimintMultimintWaitForRecovery({
-    required Multimint that,
-    required String inviteCode,
-  }) {
-    return handler.executeNormal(
-      NormalTask(
-        callFfi: (port_) {
-          final serializer = SseSerializer(generalizedFrbRustBinding);
-          sse_encode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMultimint(
-            that,
-            serializer,
-          );
-          sse_encode_String(inviteCode, serializer);
-          pdeCallFfi(
-            generalizedFrbRustBinding,
-            serializer,
-            funcId: 56,
-            port: port_,
-          );
-        },
-        codec: SseCodec(
-          decodeSuccessData:
-              sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerFederationSelector,
-          decodeErrorData: sse_decode_AnyhowException,
-        ),
-        constMeta: kCrateMultimintMultimintWaitForRecoveryConstMeta,
-        argValues: [that, inviteCode],
-        apiImpl: this,
-      ),
-    );
-  }
-
-  TaskConstMeta get kCrateMultimintMultimintWaitForRecoveryConstMeta =>
-      const TaskConstMeta(
-        debugName: "Multimint_wait_for_recovery",
-        argNames: ["that", "inviteCode"],
-      );
-
-  @override
   Future<List<Utxo>> crateMultimintMultimintWalletSummary({
     required Multimint that,
     required String invite,
@@ -3040,7 +3007,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 57,
+            funcId: 56,
             port: port_,
           );
         },
@@ -3090,7 +3057,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 58,
+            funcId: 57,
             port: port_,
           );
         },
@@ -3119,6 +3086,80 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
+  Future<void> crateNostrNostrClientBackupInviteCodes({
+    required NostrClient that,
+    required List<String> inviteCodes,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNostrClient(
+            that,
+            serializer,
+          );
+          sse_encode_list_String(inviteCodes, serializer);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 58,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_unit,
+          decodeErrorData: sse_decode_AnyhowException,
+        ),
+        constMeta: kCrateNostrNostrClientBackupInviteCodesConstMeta,
+        argValues: [that, inviteCodes],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateNostrNostrClientBackupInviteCodesConstMeta =>
+      const TaskConstMeta(
+        debugName: "NostrClient_backup_invite_codes",
+        argNames: ["that", "inviteCodes"],
+      );
+
+  @override
+  Future<List<String>> crateNostrNostrClientGetBackupInviteCodes({
+    required NostrClient that,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerNostrClient(
+            that,
+            serializer,
+          );
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 59,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_list_String,
+          decodeErrorData: null,
+        ),
+        constMeta: kCrateNostrNostrClientGetBackupInviteCodesConstMeta,
+        argValues: [that],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateNostrNostrClientGetBackupInviteCodesConstMeta =>
+      const TaskConstMeta(
+        debugName: "NostrClient_get_backup_invite_codes",
+        argNames: ["that"],
+      );
+
+  @override
   Future<List<(FederationSelector, NWCConnectionInfo)>>
   crateNostrNostrClientGetNwcConnectionInfo({required NostrClient that}) {
     return handler.executeNormal(
@@ -3132,7 +3173,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 59,
+            funcId: 60,
             port: port_,
           );
         },
@@ -3171,7 +3212,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 60,
+            funcId: 61,
             port: port_,
           );
         },
@@ -3208,7 +3249,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 61,
+            funcId: 62,
             port: port_,
           );
         },
@@ -3242,7 +3283,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 62,
+            funcId: 63,
             port: port_,
           );
         },
@@ -3283,7 +3324,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 63,
+            funcId: 64,
             port: port_,
           );
         },
@@ -3316,7 +3357,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             that,
             serializer,
           );
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 64)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 65)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_opt_String,
@@ -3347,7 +3388,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             that,
             serializer,
           );
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 65)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 66)!;
         },
         codec: SseCodec(
           decodeSuccessData:
@@ -3381,7 +3422,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             that,
             serializer,
           );
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 66)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 67)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -3414,7 +3455,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             that,
             serializer,
           );
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 67)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 68)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_list_String,
@@ -3447,7 +3488,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             that,
             serializer,
           );
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 68)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 69)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_list_String,
@@ -3479,7 +3520,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             that,
             serializer,
           );
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 69)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 70)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -3511,7 +3552,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             that,
             serializer,
           );
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 70)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 71)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_opt_String,
@@ -3545,7 +3586,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             serializer,
           );
           sse_encode_opt_String(about, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 71)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 72)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -3581,7 +3622,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             federationId,
             serializer,
           );
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 72)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 73)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -3616,7 +3657,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             serializer,
           );
           sse_encode_String(federationName, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 73)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 74)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -3651,7 +3692,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             serializer,
           );
           sse_encode_list_String(inviteCodes, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 74)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 75)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -3686,7 +3727,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             serializer,
           );
           sse_encode_list_String(modules, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 75)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 76)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -3720,7 +3761,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             serializer,
           );
           sse_encode_String(network, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 76)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 77)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -3754,7 +3795,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             serializer,
           );
           sse_encode_opt_String(picture, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 77)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 78)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -3786,7 +3827,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             that,
             serializer,
           );
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 78)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 79)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_u_64,
@@ -3819,7 +3860,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             that,
             serializer,
           );
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 79)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 80)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_f_64,
@@ -3853,7 +3894,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             that,
             serializer,
           );
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 80)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 81)!;
         },
         codec: SseCodec(
           decodeSuccessData:
@@ -3887,7 +3928,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             that,
             serializer,
           );
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 81)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 82)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_u_32,
@@ -3922,7 +3963,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             serializer,
           );
           sse_encode_u_64(feeAmount, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 82)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 83)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -3957,7 +3998,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             serializer,
           );
           sse_encode_f_64(feeRateSatsPerVb, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 83)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 84)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -3996,7 +4037,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pegOutFees,
             serializer,
           );
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 84)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 85)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -4031,7 +4072,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             serializer,
           );
           sse_encode_u_32(txSizeVbytes, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 85)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 86)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -4061,7 +4102,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 86,
+            funcId: 87,
             port: port_,
           );
         },
@@ -4094,7 +4135,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 87,
+            funcId: 88,
             port: port_,
           );
         },
@@ -4135,7 +4176,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 88,
+            funcId: 89,
             port: port_,
           );
         },
@@ -4176,7 +4217,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 89,
+            funcId: 90,
             port: port_,
           );
         },
@@ -4217,7 +4258,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 90,
+            funcId: 91,
             port: port_,
           );
         },
@@ -4258,7 +4299,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 91,
+            funcId: 92,
             port: port_,
           );
         },
@@ -4298,7 +4339,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 92,
+            funcId: 93,
             port: port_,
           );
         },
@@ -4319,6 +4360,36 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   );
 
   @override
+  Future<void> crateBackupInviteCodes({required List<String> inviteCodes}) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_list_String(inviteCodes, serializer);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 94,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_unit,
+          decodeErrorData: sse_decode_AnyhowException,
+        ),
+        constMeta: kCrateBackupInviteCodesConstMeta,
+        argValues: [inviteCodes],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateBackupInviteCodesConstMeta => const TaskConstMeta(
+    debugName: "backup_invite_codes",
+    argNames: ["inviteCodes"],
+  );
+
+  @override
   Future<BigInt> crateBalance({required FederationId federationId}) {
     return handler.executeNormal(
       NormalTask(
@@ -4331,7 +4402,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 93,
+            funcId: 95,
             port: port_,
           );
         },
@@ -4368,7 +4439,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 94,
+            funcId: 96,
             port: port_,
           );
         },
@@ -4403,7 +4474,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 95,
+            funcId: 97,
             port: port_,
           );
         },
@@ -4434,7 +4505,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 96,
+            funcId: 98,
             port: port_,
           );
         },
@@ -4469,7 +4540,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 97,
+            funcId: 99,
             port: port_,
           );
         },
@@ -4498,7 +4569,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 98,
+            funcId: 100,
             port: port_,
           );
         },
@@ -4518,6 +4589,33 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       const TaskConstMeta(debugName: "federations", argNames: []);
 
   @override
+  Future<List<String>> crateGetBackupInviteCodes() {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 101,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_list_String,
+          decodeErrorData: null,
+        ),
+        constMeta: kCrateGetBackupInviteCodesConstMeta,
+        argValues: [],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateGetBackupInviteCodesConstMeta =>
+      const TaskConstMeta(debugName: "get_backup_invite_codes", argNames: []);
+
+  @override
   Future<BigInt?> crateGetBtcPrice() {
     return handler.executeNormal(
       NormalTask(
@@ -4526,7 +4624,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 99,
+            funcId: 102,
             port: port_,
           );
         },
@@ -4553,7 +4651,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 100,
+            funcId: 103,
             port: port_,
           );
         },
@@ -4582,7 +4680,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 101,
+            funcId: 104,
             port: port_,
           );
         },
@@ -4620,7 +4718,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 102,
+            funcId: 105,
             port: port_,
           );
         },
@@ -4650,7 +4748,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 103,
+            funcId: 106,
             port: port_,
           );
         },
@@ -4678,7 +4776,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 104,
+            funcId: 107,
             port: port_,
           );
         },
@@ -4706,7 +4804,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 105,
+            funcId: 108,
             port: port_,
           );
         },
@@ -4733,7 +4831,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 106,
+            funcId: 109,
             port: port_,
           );
         },
@@ -4765,7 +4863,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 107,
+            funcId: 110,
             port: port_,
           );
         },
@@ -4798,7 +4896,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 108,
+            funcId: 111,
             port: port_,
           );
         },
@@ -4830,7 +4928,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 109,
+            funcId: 112,
             port: port_,
           );
         },
@@ -4865,7 +4963,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 110,
+            funcId: 113,
             port: port_,
           );
         },
@@ -4902,7 +5000,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 111,
+            funcId: 114,
             port: port_,
           );
         },
@@ -4939,7 +5037,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 112,
+            funcId: 115,
             port: port_,
           );
         },
@@ -4982,7 +5080,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 113,
+            funcId: 116,
             port: port_,
           );
         },
@@ -5032,7 +5130,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 114,
+            funcId: 117,
             port: port_,
           );
         },
@@ -5070,7 +5168,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 115,
+            funcId: 118,
             port: port_,
           );
         },
@@ -5111,7 +5209,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 116,
+            funcId: 119,
             port: port_,
           );
         },
@@ -5149,7 +5247,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 117,
+            funcId: 120,
             port: port_,
           );
         },
@@ -5189,7 +5287,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 118,
+            funcId: 121,
             port: port_,
           );
         },
@@ -5227,7 +5325,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 119,
+            funcId: 122,
             port: port_,
           );
         },
@@ -5265,7 +5363,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 120,
+              funcId: 123,
               port: port_,
             );
           },
@@ -5299,7 +5397,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 121,
+              funcId: 124,
               port: port_,
             );
           },
@@ -5343,7 +5441,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 122,
+            funcId: 125,
             port: port_,
           );
         },
@@ -5364,39 +5462,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   );
 
   @override
-  Future<FederationSelector> crateWaitForRecovery({
-    required String inviteCode,
-  }) {
-    return handler.executeNormal(
-      NormalTask(
-        callFfi: (port_) {
-          final serializer = SseSerializer(generalizedFrbRustBinding);
-          sse_encode_String(inviteCode, serializer);
-          pdeCallFfi(
-            generalizedFrbRustBinding,
-            serializer,
-            funcId: 123,
-            port: port_,
-          );
-        },
-        codec: SseCodec(
-          decodeSuccessData:
-              sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerFederationSelector,
-          decodeErrorData: sse_decode_AnyhowException,
-        ),
-        constMeta: kCrateWaitForRecoveryConstMeta,
-        argValues: [inviteCode],
-        apiImpl: this,
-      ),
-    );
-  }
-
-  TaskConstMeta get kCrateWaitForRecoveryConstMeta => const TaskConstMeta(
-    debugName: "wait_for_recovery",
-    argNames: ["inviteCode"],
-  );
-
-  @override
   Future<bool> crateWalletExists({required String path}) {
     return handler.executeNormal(
       NormalTask(
@@ -5406,7 +5471,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 124,
+            funcId: 126,
             port: port_,
           );
         },
@@ -5434,7 +5499,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 125,
+            funcId: 127,
             port: port_,
           );
         },
@@ -5476,7 +5541,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 126,
+            funcId: 128,
             port: port_,
           );
         },
@@ -5506,7 +5571,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 127,
+            funcId: 129,
             port: port_,
           );
         },
@@ -6558,6 +6623,8 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dco_decode_log_level(raw[1]),
           dco_decode_String(raw[2]),
         );
+      case 3:
+        return MultimintEvent_RecoveryDone(dco_decode_String(raw[1]));
       default:
         throw Exception("unreachable");
     }
@@ -7919,6 +7986,9 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         var var_field0 = sse_decode_log_level(deserializer);
         var var_field1 = sse_decode_String(deserializer);
         return MultimintEvent_Log(var_field0, var_field1);
+      case 3:
+        var var_field0 = sse_decode_String(deserializer);
+        return MultimintEvent_RecoveryDone(var_field0);
       default:
         throw UnimplementedError('');
     }
@@ -9317,6 +9387,9 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_i_32(2, serializer);
         sse_encode_log_level(field0, serializer);
         sse_encode_String(field1, serializer);
+      case MultimintEvent_RecoveryDone(field0: final field0):
+        sse_encode_i_32(3, serializer);
+        sse_encode_String(field0, serializer);
     }
   }
 
@@ -10187,12 +10260,6 @@ class MultimintImpl extends RustOpaque implements Multimint {
     modules: modules,
   );
 
-  Future<FederationSelector> waitForRecovery({required String inviteCode}) =>
-      RustLib.instance.api.crateMultimintMultimintWaitForRecovery(
-        that: this,
-        inviteCode: inviteCode,
-      );
-
   Future<List<Utxo>> walletSummary({required String invite}) => RustLib
       .instance
       .api
@@ -10230,6 +10297,15 @@ class NostrClientImpl extends RustOpaque implements NostrClient {
     rustArcDecrementStrongCountPtr:
         RustLib.instance.api.rust_arc_decrement_strong_count_NostrClientPtr,
   );
+
+  Future<void> backupInviteCodes({required List<String> inviteCodes}) =>
+      RustLib.instance.api.crateNostrNostrClientBackupInviteCodes(
+        that: this,
+        inviteCodes: inviteCodes,
+      );
+
+  Future<List<String>> getBackupInviteCodes() => RustLib.instance.api
+      .crateNostrNostrClientGetBackupInviteCodes(that: this);
 
   Future<List<(FederationSelector, NWCConnectionInfo)>>
   getNwcConnectionInfo() => RustLib.instance.api

--- a/lib/lib.dart
+++ b/lib/lib.dart
@@ -33,9 +33,6 @@ Future<bool> walletExists({required String path}) =>
 
 Future<List<String>> getMnemonic() => RustLib.instance.api.crateGetMnemonic();
 
-Future<FederationSelector> waitForRecovery({required String inviteCode}) =>
-    RustLib.instance.api.crateWaitForRecovery(inviteCode: inviteCode);
-
 Future<FederationSelector> joinFederation({
   required String inviteCode,
   required bool recover,
@@ -43,6 +40,12 @@ Future<FederationSelector> joinFederation({
   inviteCode: inviteCode,
   recover: recover,
 );
+
+Future<void> backupInviteCodes({required List<String> inviteCodes}) =>
+    RustLib.instance.api.crateBackupInviteCodes(inviteCodes: inviteCodes);
+
+Future<List<String>> getBackupInviteCodes() =>
+    RustLib.instance.api.crateGetBackupInviteCodes();
 
 Future<List<(FederationSelector, bool)>> federations() =>
     RustLib.instance.api.crateFederations();

--- a/lib/multimint.dart
+++ b/lib/multimint.dart
@@ -9,7 +9,7 @@ import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 import 'package:freezed_annotation/freezed_annotation.dart' hide protected;
 part 'multimint.freezed.dart';
 
-// These functions are ignored because they are not marked as `pub`: `await_receive_lnv1`, `await_receive_lnv2`, `await_send_lnv1`, `await_send_lnv2`, `build_client`, `cache_btc_price`, `cache_federation_meta`, `compute_receive_amount`, `compute_send_amount`, `derive_federation_secret`, `finish_active_subscriptions`, `get_client_database`, `get_lnv1_amount_from_meta`, `get_lnv1_receive_tx`, `get_lnv1_send_tx`, `get_lnv2_amount_from_meta`, `get_or_build_temp_client`, `has_federation`, `invoice_routes_back_to_federation`, `lnv1_select_gateway`, `lnv1_update_gateway_cache`, `lnv2_select_gateway`, `load_clients`, `monitor_all_unused_pegin_addresses`, `pay_lnv1`, `pay_lnv2`, `receive_amount_after_fees`, `receive_lnv1`, `receive_lnv2`, `spawn_await_ecash_reissue`, `spawn_await_ecash_send`, `spawn_await_receive`, `spawn_await_send`, `spawn_cache_task`, `spawn_pegin_address_watcher`, `spawn_recovery_progress`, `watch_pegin_address`
+// These functions are ignored because they are not marked as `pub`: `await_receive_lnv1`, `await_receive_lnv2`, `await_send_lnv1`, `await_send_lnv2`, `build_client`, `cache_btc_price`, `cache_federation_meta`, `compute_receive_amount`, `compute_send_amount`, `derive_federation_secret`, `finish_active_subscriptions`, `get_client_database`, `get_lnv1_amount_from_meta`, `get_lnv1_receive_tx`, `get_lnv1_send_tx`, `get_lnv2_amount_from_meta`, `get_or_build_temp_client`, `invoice_routes_back_to_federation`, `lnv1_select_gateway`, `lnv1_update_gateway_cache`, `lnv2_select_gateway`, `load_clients`, `monitor_all_unused_pegin_addresses`, `pay_lnv1`, `pay_lnv2`, `receive_amount_after_fees`, `receive_lnv1`, `receive_lnv2`, `spawn_await_ecash_reissue`, `spawn_await_ecash_send`, `spawn_await_receive`, `spawn_await_send`, `spawn_cache_task`, `spawn_pegin_address_watcher`, `spawn_recovery_progress`, `wait_for_recovery`, `watch_pegin_address`
 // These types are ignored because they are neither used by any `pub` functions nor (for structs and enums) marked `#[frb(unignore)]`: `ClientType`
 // These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `consensus_decode_partial_from_finite_reader`, `consensus_decode_partial_from_finite_reader`, `consensus_decode_partial_from_finite_reader`, `consensus_encode`, `consensus_encode`, `consensus_encode`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `from`
 
@@ -186,8 +186,6 @@ abstract class Multimint implements RustOpaqueInterface {
     Uint8List? operationId,
     required List<String> modules,
   });
-
-  Future<FederationSelector> waitForRecovery({required String inviteCode});
 
   Future<List<Utxo>> walletSummary({required String invite});
 
@@ -403,6 +401,8 @@ sealed class MultimintEvent with _$MultimintEvent {
   ) = MultimintEvent_Lightning;
   const factory MultimintEvent.log(LogLevel field0, String field1) =
       MultimintEvent_Log;
+  const factory MultimintEvent.recoveryDone(String field0) =
+      MultimintEvent_RecoveryDone;
 }
 
 class PaymentPreview {

--- a/lib/multimint.freezed.dart
+++ b/lib/multimint.freezed.dart
@@ -957,4 +957,70 @@ as String,
 
 }
 
+/// @nodoc
+
+
+class MultimintEvent_RecoveryDone extends MultimintEvent {
+  const MultimintEvent_RecoveryDone(this.field0): super._();
+  
+
+@override final  String field0;
+
+/// Create a copy of MultimintEvent
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$MultimintEvent_RecoveryDoneCopyWith<MultimintEvent_RecoveryDone> get copyWith => _$MultimintEvent_RecoveryDoneCopyWithImpl<MultimintEvent_RecoveryDone>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is MultimintEvent_RecoveryDone&&(identical(other.field0, field0) || other.field0 == field0));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,field0);
+
+@override
+String toString() {
+  return 'MultimintEvent.recoveryDone(field0: $field0)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $MultimintEvent_RecoveryDoneCopyWith<$Res> implements $MultimintEventCopyWith<$Res> {
+  factory $MultimintEvent_RecoveryDoneCopyWith(MultimintEvent_RecoveryDone value, $Res Function(MultimintEvent_RecoveryDone) _then) = _$MultimintEvent_RecoveryDoneCopyWithImpl;
+@useResult
+$Res call({
+ String field0
+});
+
+
+
+
+}
+/// @nodoc
+class _$MultimintEvent_RecoveryDoneCopyWithImpl<$Res>
+    implements $MultimintEvent_RecoveryDoneCopyWith<$Res> {
+  _$MultimintEvent_RecoveryDoneCopyWithImpl(this._self, this._then);
+
+  final MultimintEvent_RecoveryDone _self;
+  final $Res Function(MultimintEvent_RecoveryDone) _then;
+
+/// Create a copy of MultimintEvent
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? field0 = null,}) {
+  return _then(MultimintEvent_RecoveryDone(
+null == field0 ? _self.field0 : field0 // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+
+}
+
 // dart format on

--- a/lib/nostr.dart
+++ b/lib/nostr.dart
@@ -14,6 +14,10 @@ import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 
 // Rust type: RustOpaqueMoi<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<NostrClient>>
 abstract class NostrClient implements RustOpaqueInterface {
+  Future<void> backupInviteCodes({required List<String> inviteCodes});
+
+  Future<List<String>> getBackupInviteCodes();
+
   Future<List<(FederationSelector, NWCConnectionInfo)>> getNwcConnectionInfo();
 
   Future<List<PublicFederation>> getPublicFederations({

--- a/lib/screens/dashboard.dart
+++ b/lib/screens/dashboard.dart
@@ -47,7 +47,6 @@ class _DashboardState extends State<Dashboard> {
     recovering = widget.recovering;
     _loadBalance();
     _loadBtcPrice();
-    if (recovering) _loadFederation();
 
     events = subscribeMultimintEvents().asBroadcastStream();
     _subscription = events.listen((event) async {
@@ -64,6 +63,13 @@ class _DashboardState extends State<Dashboard> {
             _loadBalance();
           }
         }
+      } else if (event is MultimintEvent_RecoveryDone) {
+        final recoveredFedId = event.field0;
+        final currFederationId = await federationIdToString(federationId: widget.fed.federationId);
+        if (currFederationId == recoveredFedId) {
+          setState(() => recovering = false);
+          _loadBalance();
+        }
       }
     });
   }
@@ -76,12 +82,6 @@ class _DashboardState extends State<Dashboard> {
 
   void _scheduleAction(VoidCallback action) {
     setState(() => _pendingAction = action);
-  }
-
-  Future<void> _loadFederation() async {
-    await waitForRecovery(inviteCode: widget.fed.inviteCode);
-    setState(() => recovering = false);
-    _loadBalance();
   }
 
   Future<void> _loadBalance() async {

--- a/lib/splash.dart
+++ b/lib/splash.dart
@@ -31,7 +31,10 @@ class _SplashState extends State<Splash> {
     if (exists) {
       await loadMultimint(path: widget.dir.path);
       final initialFeds = await federations();
-      screen = MyApp(initialFederations: initialFeds);
+      screen = MyApp(
+        initialFederations: initialFeds,
+        recoverFederationInviteCodes: false,
+      );
     } else {
       screen = CreateWallet(dir: widget.dir);
     }

--- a/rust/carbine_fedimint/src/frb_generated.rs
+++ b/rust/carbine_fedimint/src/frb_generated.rs
@@ -42,7 +42,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.9.0";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 1203720947;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 864321999;
 
 // Section: executor
 
@@ -3302,66 +3302,6 @@ fn wire__crate__multimint__Multimint_transactions_impl(
         },
     )
 }
-fn wire__crate__multimint__Multimint_wait_for_recovery_impl(
-    port_: flutter_rust_bridge::for_generated::MessagePort,
-    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
-    rust_vec_len_: i32,
-    data_len_: i32,
-) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec, _, _, _>(
-        flutter_rust_bridge::for_generated::TaskInfo {
-            debug_name: "Multimint_wait_for_recovery",
-            port: Some(port_),
-            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
-        },
-        move || {
-            let message = unsafe {
-                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
-                    ptr_,
-                    rust_vec_len_,
-                    data_len_,
-                )
-            };
-            let mut deserializer =
-                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
-            let api_that = <RustOpaqueMoi<
-                flutter_rust_bridge::for_generated::RustAutoOpaqueInner<Multimint>,
-            >>::sse_decode(&mut deserializer);
-            let api_invite_code = <String>::sse_decode(&mut deserializer);
-            deserializer.end();
-            move |context| async move {
-                transform_result_sse::<_, flutter_rust_bridge::for_generated::anyhow::Error>(
-                    (move || async move {
-                        let mut api_that_guard = None;
-                        let decode_indices_ =
-                            flutter_rust_bridge::for_generated::lockable_compute_decode_order(
-                                vec![flutter_rust_bridge::for_generated::LockableOrderInfo::new(
-                                    &api_that, 0, true,
-                                )],
-                            );
-                        for i in decode_indices_ {
-                            match i {
-                                0 => {
-                                    api_that_guard =
-                                        Some(api_that.lockable_decode_async_ref_mut().await)
-                                }
-                                _ => unreachable!(),
-                            }
-                        }
-                        let mut api_that_guard = api_that_guard.unwrap();
-                        let output_ok = crate::multimint::Multimint::wait_for_recovery(
-                            &mut *api_that_guard,
-                            api_invite_code,
-                        )
-                        .await?;
-                        Ok(output_ok)
-                    })()
-                    .await,
-                )
-            }
-        },
-    )
-}
 fn wire__crate__multimint__Multimint_wallet_summary_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
@@ -3495,6 +3435,124 @@ fn wire__crate__multimint__Multimint_withdraw_to_address_impl(
                             api_peg_out_fees,
                         )
                         .await?;
+                        Ok(output_ok)
+                    })()
+                    .await,
+                )
+            }
+        },
+    )
+}
+fn wire__crate__nostr__NostrClient_backup_invite_codes_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec, _, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "NostrClient_backup_invite_codes",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_that = <RustOpaqueMoi<
+                flutter_rust_bridge::for_generated::RustAutoOpaqueInner<NostrClient>,
+            >>::sse_decode(&mut deserializer);
+            let api_invite_codes = <Vec<String>>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| async move {
+                transform_result_sse::<_, flutter_rust_bridge::for_generated::anyhow::Error>(
+                    (move || async move {
+                        let mut api_that_guard = None;
+                        let decode_indices_ =
+                            flutter_rust_bridge::for_generated::lockable_compute_decode_order(
+                                vec![flutter_rust_bridge::for_generated::LockableOrderInfo::new(
+                                    &api_that, 0, false,
+                                )],
+                            );
+                        for i in decode_indices_ {
+                            match i {
+                                0 => {
+                                    api_that_guard =
+                                        Some(api_that.lockable_decode_async_ref().await)
+                                }
+                                _ => unreachable!(),
+                            }
+                        }
+                        let api_that_guard = api_that_guard.unwrap();
+                        let output_ok = crate::nostr::NostrClient::backup_invite_codes(
+                            &*api_that_guard,
+                            api_invite_codes,
+                        )
+                        .await?;
+                        Ok(output_ok)
+                    })()
+                    .await,
+                )
+            }
+        },
+    )
+}
+fn wire__crate__nostr__NostrClient_get_backup_invite_codes_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec, _, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "NostrClient_get_backup_invite_codes",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_that = <RustOpaqueMoi<
+                flutter_rust_bridge::for_generated::RustAutoOpaqueInner<NostrClient>,
+            >>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| async move {
+                transform_result_sse::<_, ()>(
+                    (move || async move {
+                        let mut api_that_guard = None;
+                        let decode_indices_ =
+                            flutter_rust_bridge::for_generated::lockable_compute_decode_order(
+                                vec![flutter_rust_bridge::for_generated::LockableOrderInfo::new(
+                                    &api_that, 0, false,
+                                )],
+                            );
+                        for i in decode_indices_ {
+                            match i {
+                                0 => {
+                                    api_that_guard =
+                                        Some(api_that.lockable_decode_async_ref().await)
+                                }
+                                _ => unreachable!(),
+                            }
+                        }
+                        let api_that_guard = api_that_guard.unwrap();
+                        let output_ok = Result::<_, ()>::Ok(
+                            crate::nostr::NostrClient::get_backup_invite_codes(&*api_that_guard)
+                                .await,
+                        )?;
                         Ok(output_ok)
                     })()
                     .await,
@@ -5220,6 +5278,42 @@ fn wire__crate__await_withdraw_impl(
         },
     )
 }
+fn wire__crate__backup_invite_codes_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec, _, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "backup_invite_codes",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_invite_codes = <Vec<String>>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| async move {
+                transform_result_sse::<_, flutter_rust_bridge::for_generated::anyhow::Error>(
+                    (move || async move {
+                        let output_ok = crate::backup_invite_codes(api_invite_codes).await?;
+                        Ok(output_ok)
+                    })()
+                    .await,
+                )
+            }
+        },
+    )
+}
 fn wire__crate__balance_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
@@ -5484,6 +5578,42 @@ fn wire__crate__federations_impl(
                 transform_result_sse::<_, ()>(
                     (move || async move {
                         let output_ok = Result::<_, ()>::Ok(crate::federations().await)?;
+                        Ok(output_ok)
+                    })()
+                    .await,
+                )
+            }
+        },
+    )
+}
+fn wire__crate__get_backup_invite_codes_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec, _, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "get_backup_invite_codes",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            deserializer.end();
+            move |context| async move {
+                transform_result_sse::<_, ()>(
+                    (move || async move {
+                        let output_ok =
+                            Result::<_, ()>::Ok(crate::get_backup_invite_codes().await)?;
                         Ok(output_ok)
                     })()
                     .await,
@@ -6636,42 +6766,6 @@ fn wire__crate__transactions_impl(
         },
     )
 }
-fn wire__crate__wait_for_recovery_impl(
-    port_: flutter_rust_bridge::for_generated::MessagePort,
-    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
-    rust_vec_len_: i32,
-    data_len_: i32,
-) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec, _, _, _>(
-        flutter_rust_bridge::for_generated::TaskInfo {
-            debug_name: "wait_for_recovery",
-            port: Some(port_),
-            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
-        },
-        move || {
-            let message = unsafe {
-                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
-                    ptr_,
-                    rust_vec_len_,
-                    data_len_,
-                )
-            };
-            let mut deserializer =
-                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
-            let api_invite_code = <String>::sse_decode(&mut deserializer);
-            deserializer.end();
-            move |context| async move {
-                transform_result_sse::<_, flutter_rust_bridge::for_generated::anyhow::Error>(
-                    (move || async move {
-                        let output_ok = crate::wait_for_recovery(api_invite_code).await?;
-                        Ok(output_ok)
-                    })()
-                    .await,
-                )
-            }
-        },
-    )
-}
 fn wire__crate__wallet_exists_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
@@ -7688,6 +7782,10 @@ impl SseDecode for crate::multimint::MultimintEvent {
                 let mut var_field1 = <String>::sse_decode(deserializer);
                 return crate::multimint::MultimintEvent::Log(var_field0, var_field1);
             }
+            3 => {
+                let mut var_field0 = <String>::sse_decode(deserializer);
+                return crate::multimint::MultimintEvent::RecoveryDone(var_field0);
+            }
             _ => {
                 unimplemented!("");
             }
@@ -8028,83 +8126,90 @@ fn pde_ffi_dispatcher_primary_impl(
         55 => {
             wire__crate__multimint__Multimint_transactions_impl(port, ptr, rust_vec_len, data_len)
         }
-        56 => wire__crate__multimint__Multimint_wait_for_recovery_impl(
-            port,
-            ptr,
-            rust_vec_len,
-            data_len,
-        ),
-        57 => {
+        56 => {
             wire__crate__multimint__Multimint_wallet_summary_impl(port, ptr, rust_vec_len, data_len)
         }
-        58 => wire__crate__multimint__Multimint_withdraw_to_address_impl(
+        57 => wire__crate__multimint__Multimint_withdraw_to_address_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        59 => wire__crate__nostr__NostrClient_get_nwc_connection_info_impl(
+        58 => wire__crate__nostr__NostrClient_backup_invite_codes_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        60 => wire__crate__nostr__NostrClient_get_public_federations_impl(
+        59 => wire__crate__nostr__NostrClient_get_backup_invite_codes_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        61 => wire__crate__nostr__NostrClient_get_relays_impl(port, ptr, rust_vec_len, data_len),
-        62 => wire__crate__nostr__NostrClient_new_impl(port, ptr, rust_vec_len, data_len),
-        63 => wire__crate__nostr__NostrClient_set_nwc_connection_info_impl(
+        60 => wire__crate__nostr__NostrClient_get_nwc_connection_info_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        86 => wire__crate__ack_seed_phrase_impl(port, ptr, rust_vec_len, data_len),
-        87 => wire__crate__allocate_deposit_address_impl(port, ptr, rust_vec_len, data_len),
-        88 => wire__crate__await_ecash_reissue_impl(port, ptr, rust_vec_len, data_len),
-        89 => wire__crate__await_ecash_send_impl(port, ptr, rust_vec_len, data_len),
-        90 => wire__crate__await_receive_impl(port, ptr, rust_vec_len, data_len),
-        91 => wire__crate__await_send_impl(port, ptr, rust_vec_len, data_len),
-        92 => wire__crate__await_withdraw_impl(port, ptr, rust_vec_len, data_len),
-        93 => wire__crate__balance_impl(port, ptr, rust_vec_len, data_len),
-        94 => wire__crate__calculate_withdraw_fees_impl(port, ptr, rust_vec_len, data_len),
-        95 => wire__crate__create_multimint_from_words_impl(port, ptr, rust_vec_len, data_len),
-        96 => wire__crate__create_new_multimint_impl(port, ptr, rust_vec_len, data_len),
-        97 => wire__crate__federation_id_to_string_impl(port, ptr, rust_vec_len, data_len),
-        98 => wire__crate__federations_impl(port, ptr, rust_vec_len, data_len),
-        99 => wire__crate__get_btc_price_impl(port, ptr, rust_vec_len, data_len),
-        100 => wire__crate__get_event_bus_impl(port, ptr, rust_vec_len, data_len),
-        101 => wire__crate__get_federation_meta_impl(port, ptr, rust_vec_len, data_len),
-        102 => wire__crate__get_max_withdrawable_amount_impl(port, ptr, rust_vec_len, data_len),
-        103 => wire__crate__get_mnemonic_impl(port, ptr, rust_vec_len, data_len),
-        104 => wire__crate__get_nwc_connection_info_impl(port, ptr, rust_vec_len, data_len),
-        105 => wire__crate__get_relays_impl(port, ptr, rust_vec_len, data_len),
-        106 => wire__crate__has_seed_phrase_ack_impl(port, ptr, rust_vec_len, data_len),
-        107 => wire__crate__join_federation_impl(port, ptr, rust_vec_len, data_len),
-        108 => wire__crate__list_federations_from_nostr_impl(port, ptr, rust_vec_len, data_len),
-        109 => wire__crate__load_multimint_impl(port, ptr, rust_vec_len, data_len),
-        110 => wire__crate__monitor_deposit_address_impl(port, ptr, rust_vec_len, data_len),
-        111 => wire__crate__parse_ecash_impl(port, ptr, rust_vec_len, data_len),
-        112 => wire__crate__payment_preview_impl(port, ptr, rust_vec_len, data_len),
-        113 => wire__crate__receive_impl(port, ptr, rust_vec_len, data_len),
-        114 => wire__crate__reissue_ecash_impl(port, ptr, rust_vec_len, data_len),
-        115 => wire__crate__select_receive_gateway_impl(port, ptr, rust_vec_len, data_len),
-        116 => wire__crate__send_impl(port, ptr, rust_vec_len, data_len),
-        117 => wire__crate__send_ecash_impl(port, ptr, rust_vec_len, data_len),
-        118 => wire__crate__send_lnaddress_impl(port, ptr, rust_vec_len, data_len),
-        119 => wire__crate__set_nwc_connection_info_impl(port, ptr, rust_vec_len, data_len),
-        120 => wire__crate__subscribe_deposits_impl(port, ptr, rust_vec_len, data_len),
-        121 => wire__crate__subscribe_multimint_events_impl(port, ptr, rust_vec_len, data_len),
-        122 => wire__crate__transactions_impl(port, ptr, rust_vec_len, data_len),
-        123 => wire__crate__wait_for_recovery_impl(port, ptr, rust_vec_len, data_len),
-        124 => wire__crate__wallet_exists_impl(port, ptr, rust_vec_len, data_len),
-        125 => wire__crate__wallet_summary_impl(port, ptr, rust_vec_len, data_len),
-        126 => wire__crate__withdraw_to_address_impl(port, ptr, rust_vec_len, data_len),
-        127 => wire__crate__word_list_impl(port, ptr, rust_vec_len, data_len),
+        61 => wire__crate__nostr__NostrClient_get_public_federations_impl(
+            port,
+            ptr,
+            rust_vec_len,
+            data_len,
+        ),
+        62 => wire__crate__nostr__NostrClient_get_relays_impl(port, ptr, rust_vec_len, data_len),
+        63 => wire__crate__nostr__NostrClient_new_impl(port, ptr, rust_vec_len, data_len),
+        64 => wire__crate__nostr__NostrClient_set_nwc_connection_info_impl(
+            port,
+            ptr,
+            rust_vec_len,
+            data_len,
+        ),
+        87 => wire__crate__ack_seed_phrase_impl(port, ptr, rust_vec_len, data_len),
+        88 => wire__crate__allocate_deposit_address_impl(port, ptr, rust_vec_len, data_len),
+        89 => wire__crate__await_ecash_reissue_impl(port, ptr, rust_vec_len, data_len),
+        90 => wire__crate__await_ecash_send_impl(port, ptr, rust_vec_len, data_len),
+        91 => wire__crate__await_receive_impl(port, ptr, rust_vec_len, data_len),
+        92 => wire__crate__await_send_impl(port, ptr, rust_vec_len, data_len),
+        93 => wire__crate__await_withdraw_impl(port, ptr, rust_vec_len, data_len),
+        94 => wire__crate__backup_invite_codes_impl(port, ptr, rust_vec_len, data_len),
+        95 => wire__crate__balance_impl(port, ptr, rust_vec_len, data_len),
+        96 => wire__crate__calculate_withdraw_fees_impl(port, ptr, rust_vec_len, data_len),
+        97 => wire__crate__create_multimint_from_words_impl(port, ptr, rust_vec_len, data_len),
+        98 => wire__crate__create_new_multimint_impl(port, ptr, rust_vec_len, data_len),
+        99 => wire__crate__federation_id_to_string_impl(port, ptr, rust_vec_len, data_len),
+        100 => wire__crate__federations_impl(port, ptr, rust_vec_len, data_len),
+        101 => wire__crate__get_backup_invite_codes_impl(port, ptr, rust_vec_len, data_len),
+        102 => wire__crate__get_btc_price_impl(port, ptr, rust_vec_len, data_len),
+        103 => wire__crate__get_event_bus_impl(port, ptr, rust_vec_len, data_len),
+        104 => wire__crate__get_federation_meta_impl(port, ptr, rust_vec_len, data_len),
+        105 => wire__crate__get_max_withdrawable_amount_impl(port, ptr, rust_vec_len, data_len),
+        106 => wire__crate__get_mnemonic_impl(port, ptr, rust_vec_len, data_len),
+        107 => wire__crate__get_nwc_connection_info_impl(port, ptr, rust_vec_len, data_len),
+        108 => wire__crate__get_relays_impl(port, ptr, rust_vec_len, data_len),
+        109 => wire__crate__has_seed_phrase_ack_impl(port, ptr, rust_vec_len, data_len),
+        110 => wire__crate__join_federation_impl(port, ptr, rust_vec_len, data_len),
+        111 => wire__crate__list_federations_from_nostr_impl(port, ptr, rust_vec_len, data_len),
+        112 => wire__crate__load_multimint_impl(port, ptr, rust_vec_len, data_len),
+        113 => wire__crate__monitor_deposit_address_impl(port, ptr, rust_vec_len, data_len),
+        114 => wire__crate__parse_ecash_impl(port, ptr, rust_vec_len, data_len),
+        115 => wire__crate__payment_preview_impl(port, ptr, rust_vec_len, data_len),
+        116 => wire__crate__receive_impl(port, ptr, rust_vec_len, data_len),
+        117 => wire__crate__reissue_ecash_impl(port, ptr, rust_vec_len, data_len),
+        118 => wire__crate__select_receive_gateway_impl(port, ptr, rust_vec_len, data_len),
+        119 => wire__crate__send_impl(port, ptr, rust_vec_len, data_len),
+        120 => wire__crate__send_ecash_impl(port, ptr, rust_vec_len, data_len),
+        121 => wire__crate__send_lnaddress_impl(port, ptr, rust_vec_len, data_len),
+        122 => wire__crate__set_nwc_connection_info_impl(port, ptr, rust_vec_len, data_len),
+        123 => wire__crate__subscribe_deposits_impl(port, ptr, rust_vec_len, data_len),
+        124 => wire__crate__subscribe_multimint_events_impl(port, ptr, rust_vec_len, data_len),
+        125 => wire__crate__transactions_impl(port, ptr, rust_vec_len, data_len),
+        126 => wire__crate__wallet_exists_impl(port, ptr, rust_vec_len, data_len),
+        127 => wire__crate__wallet_summary_impl(port, ptr, rust_vec_len, data_len),
+        128 => wire__crate__withdraw_to_address_impl(port, ptr, rust_vec_len, data_len),
+        129 => wire__crate__word_list_impl(port, ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }
@@ -8257,116 +8362,116 @@ fn pde_ffi_dispatcher_sync_impl(
             rust_vec_len,
             data_len,
         ),
-        64 => wire__crate__nostr__PublicFederation_auto_accessor_get_about_impl(
+        65 => wire__crate__nostr__PublicFederation_auto_accessor_get_about_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        65 => wire__crate__nostr__PublicFederation_auto_accessor_get_federation_id_impl(
+        66 => wire__crate__nostr__PublicFederation_auto_accessor_get_federation_id_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        66 => wire__crate__nostr__PublicFederation_auto_accessor_get_federation_name_impl(
+        67 => wire__crate__nostr__PublicFederation_auto_accessor_get_federation_name_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        67 => wire__crate__nostr__PublicFederation_auto_accessor_get_invite_codes_impl(
+        68 => wire__crate__nostr__PublicFederation_auto_accessor_get_invite_codes_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        68 => wire__crate__nostr__PublicFederation_auto_accessor_get_modules_impl(
+        69 => wire__crate__nostr__PublicFederation_auto_accessor_get_modules_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        69 => wire__crate__nostr__PublicFederation_auto_accessor_get_network_impl(
+        70 => wire__crate__nostr__PublicFederation_auto_accessor_get_network_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        70 => wire__crate__nostr__PublicFederation_auto_accessor_get_picture_impl(
+        71 => wire__crate__nostr__PublicFederation_auto_accessor_get_picture_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        71 => wire__crate__nostr__PublicFederation_auto_accessor_set_about_impl(
+        72 => wire__crate__nostr__PublicFederation_auto_accessor_set_about_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        72 => wire__crate__nostr__PublicFederation_auto_accessor_set_federation_id_impl(
+        73 => wire__crate__nostr__PublicFederation_auto_accessor_set_federation_id_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        73 => wire__crate__nostr__PublicFederation_auto_accessor_set_federation_name_impl(
+        74 => wire__crate__nostr__PublicFederation_auto_accessor_set_federation_name_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        74 => wire__crate__nostr__PublicFederation_auto_accessor_set_invite_codes_impl(
+        75 => wire__crate__nostr__PublicFederation_auto_accessor_set_invite_codes_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        75 => wire__crate__nostr__PublicFederation_auto_accessor_set_modules_impl(
+        76 => wire__crate__nostr__PublicFederation_auto_accessor_set_modules_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        76 => wire__crate__nostr__PublicFederation_auto_accessor_set_network_impl(
+        77 => wire__crate__nostr__PublicFederation_auto_accessor_set_network_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        77 => wire__crate__nostr__PublicFederation_auto_accessor_set_picture_impl(
+        78 => wire__crate__nostr__PublicFederation_auto_accessor_set_picture_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        78 => wire__crate__multimint__WithdrawFeesResponse_auto_accessor_get_fee_amount_impl(
+        79 => wire__crate__multimint__WithdrawFeesResponse_auto_accessor_get_fee_amount_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        79 => {
+        80 => {
             wire__crate__multimint__WithdrawFeesResponse_auto_accessor_get_fee_rate_sats_per_vb_impl(
                 ptr,
                 rust_vec_len,
                 data_len,
             )
         }
-        80 => wire__crate__multimint__WithdrawFeesResponse_auto_accessor_get_peg_out_fees_impl(
+        81 => wire__crate__multimint__WithdrawFeesResponse_auto_accessor_get_peg_out_fees_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        81 => wire__crate__multimint__WithdrawFeesResponse_auto_accessor_get_tx_size_vbytes_impl(
+        82 => wire__crate__multimint__WithdrawFeesResponse_auto_accessor_get_tx_size_vbytes_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        82 => wire__crate__multimint__WithdrawFeesResponse_auto_accessor_set_fee_amount_impl(
+        83 => wire__crate__multimint__WithdrawFeesResponse_auto_accessor_set_fee_amount_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        83 => {
+        84 => {
             wire__crate__multimint__WithdrawFeesResponse_auto_accessor_set_fee_rate_sats_per_vb_impl(
                 ptr,
                 rust_vec_len,
                 data_len,
             )
         }
-        84 => wire__crate__multimint__WithdrawFeesResponse_auto_accessor_set_peg_out_fees_impl(
+        85 => wire__crate__multimint__WithdrawFeesResponse_auto_accessor_set_peg_out_fees_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        85 => wire__crate__multimint__WithdrawFeesResponse_auto_accessor_set_tx_size_vbytes_impl(
+        86 => wire__crate__multimint__WithdrawFeesResponse_auto_accessor_set_tx_size_vbytes_impl(
             ptr,
             rust_vec_len,
             data_len,
@@ -8975,6 +9080,9 @@ impl flutter_rust_bridge::IntoDart for crate::multimint::MultimintEvent {
                 field1.into_into_dart().into_dart(),
             ]
             .into_dart(),
+            crate::multimint::MultimintEvent::RecoveryDone(field0) => {
+                [3.into_dart(), field0.into_into_dart().into_dart()].into_dart()
+            }
             _ => {
                 unimplemented!("");
             }
@@ -9781,6 +9889,10 @@ impl SseEncode for crate::multimint::MultimintEvent {
                 <i32>::sse_encode(2, serializer);
                 <crate::multimint::LogLevel>::sse_encode(field0, serializer);
                 <String>::sse_encode(field1, serializer);
+            }
+            crate::multimint::MultimintEvent::RecoveryDone(field0) => {
+                <i32>::sse_encode(3, serializer);
+                <String>::sse_encode(field0, serializer);
             }
             _ => {
                 unimplemented!("");

--- a/rust/carbine_fedimint/src/lib.rs
+++ b/rust/carbine_fedimint/src/lib.rs
@@ -9,13 +9,13 @@ use db::SeedPhraseAckKey;
 use event_bus::EventBus;
 use fedimint_core::config::ClientConfig;
 /* AUTO INJECTED BY flutter_rust_bridge. This line may not be accurate, and you can change it according to your needs. */
+use fedimint_wallet_client::PegOutFees;
 use flutter_rust_bridge::frb;
 use futures_util::StreamExt;
 use multimint::{
     FederationMeta, FederationSelector, LightningSendOutcome, LogLevel, Multimint,
     MultimintCreation, MultimintEvent, PaymentPreview, Transaction, Utxo, WithdrawFeesResponse,
 };
-use fedimint_wallet_client::PegOutFees;
 use nostr::{NWCConnectionInfo, NostrClient, PublicFederation};
 use tokio::sync::{OnceCell, RwLock};
 
@@ -164,12 +164,6 @@ pub async fn get_mnemonic() -> Vec<String> {
 }
 
 #[frb]
-pub async fn wait_for_recovery(invite_code: String) -> anyhow::Result<FederationSelector> {
-    let mut multimint = get_multimint();
-    multimint.wait_for_recovery(invite_code).await
-}
-
-#[frb]
 pub async fn join_federation(
     invite_code: String,
     recover: bool,
@@ -178,6 +172,20 @@ pub async fn join_federation(
     multimint
         .join_federation(invite_code.clone(), recover)
         .await
+}
+
+#[frb]
+pub async fn backup_invite_codes(invite_codes: Vec<String>) -> anyhow::Result<()> {
+    let nostr_client = get_nostr_client();
+    let nostr = nostr_client.read().await;
+    nostr.backup_invite_codes(invite_codes).await
+}
+
+#[frb]
+pub async fn get_backup_invite_codes() -> Vec<String> {
+    let nostr_client = get_nostr_client();
+    let nostr = nostr_client.read().await;
+    nostr.get_backup_invite_codes().await
 }
 
 #[frb]


### PR DESCRIPTION
Closes: https://github.com/fedimint/fedimint-app/issues/33

Automatically backs up federation invite codes to Nostr using a replaceable event. Retrieves these invite codes when recovering and auto-rejoins the federation.