### PR TITLE
fix: change defaults and turn off lightning address

### DIFF
--- a/lib/ln_address.dart
+++ b/lib/ln_address.dart
@@ -23,8 +23,8 @@ class LightningAddressScreen extends StatefulWidget {
 }
 
 class _LightningAddressScreenState extends State<LightningAddressScreen> {
-  String _lnAddressApi = "http://localhost:8080";
-  String _recurringdApi = "http://localhost:21665";
+  String _lnAddressApi = "https://lnaddress.mplsfed.xyz";
+  String _recurringdApi = "https://recurringd.mplsfed.xyz";
   bool _loading = true;
   FederationSelector? _selectedFederation;
 

--- a/lib/setttings.dart
+++ b/lib/setttings.dart
@@ -1,6 +1,5 @@
 import 'package:carbine/discover.dart';
 import 'package:carbine/lib.dart';
-import 'package:carbine/ln_address.dart';
 import 'package:carbine/mnemonic.dart';
 import 'package:carbine/multimint.dart';
 import 'package:carbine/nwc.dart';
@@ -63,6 +62,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
               );
             },
           ),
+          /*
           _SettingsOption(
             icon: Icons.flash_on,
             title: 'Lightning Address',
@@ -81,6 +81,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
               );
             },
           ),
+          */
           _SettingsOption(
             icon: Icons.link,
             title: 'Nostr Wallet Connect',


### PR DESCRIPTION
Lightning Address isn't quite ready yet, but I wanted to merge it to avoid conflicts moving forward. For now we will just comment out the Settings option, so we can re-enable it when ready.