### PR TITLE
feat: build APK in CI

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -1,0 +1,126 @@
+name: Android Release
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - '**'
+
+# Add permissions block
+permissions:
+  contents: write  # Required for creating releases
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Get short SHA
+        id: slug
+        run: echo "sha8=$(echo ${GITHUB_SHA} | cut -c1-8)" >> $GITHUB_OUTPUT
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.32.4'
+          channel: 'stable'
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+          targets: aarch64-linux-android,armv7-linux-androideabi,x86_64-linux-android,i686-linux-android
+
+      - name: Set up Android NDK
+        uses: nttld/setup-ndk@v1
+        id: setup-ndk
+        with:
+          ndk-version: r25c
+
+      - name: Set Android environment variables
+        run: |
+          echo "ANDROID_NDK_HOME=${{ steps.setup-ndk.outputs.ndk-path }}" >> $GITHUB_ENV
+          echo "ANDROID_NDK_ROOT=${{ steps.setup-ndk.outputs.ndk-path }}" >> $GITHUB_ENV
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y zlib1g-dev clang libclang-dev libc6-dev-i386
+
+      - name: Install cargo-ndk
+        run: cargo install cargo-ndk
+
+      - name: Install Flutter dependencies
+        run: flutter pub get
+
+      - name: Build Rust library for Android
+        run: |
+          # Set up directories
+          ROOT="$(pwd)"
+          RUST_DIR="$ROOT/rust/carbine_fedimint"
+          JNI_LIBS_DIR="$ROOT/android/app/src/main/jniLibs/arm64-v8a"
+          mkdir -p "$JNI_LIBS_DIR"
+          
+          # Set up cross-compiler environment variables for Linux
+          export CC_aarch64_linux_android="$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android21-clang"
+          export CXX_aarch64_linux_android="$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android21-clang++"
+          export AR_aarch64_linux_android="$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-ar"
+          export CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER="$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android21-clang"
+          
+          # Set up sysroot for proper header files
+          export CFLAGS_aarch64_linux_android="--sysroot=$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/sysroot"
+          export CXXFLAGS_aarch64_linux_android="--sysroot=$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/sysroot"
+          
+          # Set bindgen to use the Android sysroot
+          export BINDGEN_EXTRA_CLANG_ARGS_aarch64_linux_android="--sysroot=$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/sysroot -I$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/include -I$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/include/aarch64-linux-android"
+          
+          # Build the Rust library for Android ARM64
+          cd "$RUST_DIR"
+          cargo ndk -t arm64-v8a -o "$JNI_LIBS_DIR" build --release --target aarch64-linux-android
+          
+          # Move any .so files from nested subdirectories up to JNI_LIBS_DIR
+          find "$JNI_LIBS_DIR" -type f -name '*.so' -exec mv {} "$JNI_LIBS_DIR" \;
+          find "$JNI_LIBS_DIR" -type d -empty -delete
+          
+          # Copy the C++ shared library
+          cp "$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/lib/aarch64-linux-android/libc++_shared.so" "$JNI_LIBS_DIR/" 2>/dev/null || true
+
+      - name: Setup Release Keystore
+        run: |
+          # Create keystore directory
+          mkdir -p android
+          
+          # Decode keystore from GitHub secret (base64 encoded)
+          echo "${{ secrets.ANDROID_KEYSTORE }}" | base64 -d > android/release-keystore.jks
+          
+          # Create key.properties file from secrets
+          cat > android/key.properties << EOF
+          storePassword=${{ secrets.KEYSTORE_PASSWORD }}
+          keyPassword=${{ secrets.KEY_PASSWORD }}
+          keyAlias=${{ secrets.KEY_ALIAS }}
+          storeFile=release-keystore.jks
+          EOF
+
+      - name: Build Flutter APK
+        run: flutter build apk --release
+
+      - name: Rename APK
+        run: mv build/app/outputs/flutter-apk/app-release.apk build/app/outputs/flutter-apk/fedimint-app-${{ steps.slug.outputs.sha8 }}.apk
+
+      - name: Upload to Release
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        uses: ncipollo/release-action@v1
+        with:
+          tag: latest
+          name: "Latest Android Release"
+          artifacts: "build/app/outputs/flutter-apk/fedimint-app-${{ steps.slug.outputs.sha8 }}.apk"
+          allowUpdates: true
+          replacesArtifacts: true
+          draft: false
+          prerelease: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 


### PR DESCRIPTION
Will require the following secrets to be set first:

* `ANDROID_KEYSTORE`
* `KEYSTORE_PASSWORD`
* `KEY_PASSWORD`
* `KEY_ALIAS`

I can use the testing key I used so far or @m1sterc001guy or @bradleystachurski can generate one. I don't mind too much, let's just back it up properly :smile: 

See this CI run as an example (without the hash suffix in the APK name yet and still called puncture, I fixed that afterwards for this PR): https://github.com/elsirion/fedimint-app/actions/runs/16388717670/job/46311840212