### PR TITLE
fix: add more try catches and remove unused functions

### DIFF
--- a/lib/fed_preview.dart
+++ b/lib/fed_preview.dart
@@ -438,13 +438,23 @@ class _FederationUtxoListState extends State<FederationUtxoList> {
   }
 
   Future<void> _loadWalletSummary() async {
-    final summary = await walletSummary(
-      invite: widget.invite,
-      federationId: widget.fed.federationId,
-    );
-    setState(() {
-      utxos = summary;
-    });
+    try {
+      final summary = await walletSummary(
+        invite: widget.invite,
+        federationId: widget.fed.federationId,
+      );
+      setState(() {
+        utxos = summary;
+      });
+    } catch (e) {
+      AppLogger.instance.error("Could not load wallet summary: $e");
+      ToastService().show(
+        message: "Could not load Federation's UTXOs",
+        duration: const Duration(seconds: 5),
+        onTap: () {},
+        icon: Icon(Icons.error),
+      );
+    }
   }
 
   String? _explorerUrl(String txid) {

--- a/lib/frb_generated.dart
+++ b/lib/frb_generated.dart
@@ -66,7 +66,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.9.0';
 
   @override
-  int get rustContentHash => -1459010334;
+  int get rustContentHash => -1087282765;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -643,11 +643,6 @@ abstract class RustLibApi extends BaseApi {
   });
 
   Future<(ReissueExternalNotesState, BigInt?)> crateAwaitEcashReissue({
-    required FederationId federationId,
-    required OperationId operationId,
-  });
-
-  Future<SpendOobState> crateAwaitEcashSend({
     required FederationId federationId,
     required OperationId operationId,
   });
@@ -5553,47 +5548,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   );
 
   @override
-  Future<SpendOobState> crateAwaitEcashSend({
-    required FederationId federationId,
-    required OperationId operationId,
-  }) {
-    return handler.executeNormal(
-      NormalTask(
-        callFfi: (port_) {
-          final serializer = SseSerializer(generalizedFrbRustBinding);
-          sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerFederationId(
-            federationId,
-            serializer,
-          );
-          sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerOperationId(
-            operationId,
-            serializer,
-          );
-          pdeCallFfi(
-            generalizedFrbRustBinding,
-            serializer,
-            funcId: 116,
-            port: port_,
-          );
-        },
-        codec: SseCodec(
-          decodeSuccessData:
-              sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerSpendOOBState,
-          decodeErrorData: sse_decode_AnyhowException,
-        ),
-        constMeta: kCrateAwaitEcashSendConstMeta,
-        argValues: [federationId, operationId],
-        apiImpl: this,
-      ),
-    );
-  }
-
-  TaskConstMeta get kCrateAwaitEcashSendConstMeta => const TaskConstMeta(
-    debugName: "await_ecash_send",
-    argNames: ["federationId", "operationId"],
-  );
-
-  @override
   Future<(FinalReceiveOperationState, BigInt)> crateAwaitReceive({
     required FederationId federationId,
     required OperationId operationId,
@@ -5613,7 +5567,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 117,
+            funcId: 116,
             port: port_,
           );
         },
@@ -5654,7 +5608,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 118,
+            funcId: 117,
             port: port_,
           );
         },
@@ -5694,7 +5648,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 119,
+            funcId: 118,
             port: port_,
           );
         },
@@ -5723,7 +5677,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 120,
+            funcId: 119,
             port: port_,
           );
         },
@@ -5754,7 +5708,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 121,
+            funcId: 120,
             port: port_,
           );
         },
@@ -5791,7 +5745,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 122,
+            funcId: 121,
             port: port_,
           );
         },
@@ -5829,7 +5783,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 123,
+            funcId: 122,
             port: port_,
           );
         },
@@ -5872,7 +5826,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 124,
+            funcId: 123,
             port: port_,
           );
         },
@@ -5919,7 +5873,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 125,
+            funcId: 124,
             port: port_,
           );
         },
@@ -5950,7 +5904,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 126,
+            funcId: 125,
             port: port_,
           );
         },
@@ -5985,7 +5939,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 127,
+            funcId: 126,
             port: port_,
           );
         },
@@ -6014,7 +5968,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 128,
+            funcId: 127,
             port: port_,
           );
         },
@@ -6048,7 +6002,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 129,
+            funcId: 128,
             port: port_,
           );
         },
@@ -6078,7 +6032,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 130,
+            funcId: 129,
             port: port_,
           );
         },
@@ -6105,7 +6059,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 131,
+            funcId: 130,
             port: port_,
           );
         },
@@ -6132,7 +6086,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 132,
+            funcId: 131,
             port: port_,
           );
         },
@@ -6168,7 +6122,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 133,
+            funcId: 132,
             port: port_,
           );
         },
@@ -6206,7 +6160,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 134,
+            funcId: 133,
             port: port_,
           );
         },
@@ -6241,7 +6195,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 135,
+            funcId: 134,
             port: port_,
           );
         },
@@ -6279,7 +6233,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 136,
+            funcId: 135,
             port: port_,
           );
         },
@@ -6309,7 +6263,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 137,
+            funcId: 136,
             port: port_,
           );
         },
@@ -6344,7 +6298,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 138,
+            funcId: 137,
             port: port_,
           );
         },
@@ -6380,7 +6334,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 139,
+            funcId: 138,
             port: port_,
           );
         },
@@ -6410,7 +6364,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 140,
+            funcId: 139,
             port: port_,
           );
         },
@@ -6438,7 +6392,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 141,
+            funcId: 140,
             port: port_,
           );
         },
@@ -6465,7 +6419,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 142,
+            funcId: 141,
             port: port_,
           );
         },
@@ -6493,7 +6447,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 143,
+            funcId: 142,
             port: port_,
           );
         },
@@ -6525,7 +6479,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 144,
+            funcId: 143,
             port: port_,
           );
         },
@@ -6558,7 +6512,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 145,
+            funcId: 144,
             port: port_,
           );
         },
@@ -6595,7 +6549,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 146,
+            funcId: 145,
             port: port_,
           );
         },
@@ -6627,7 +6581,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 147,
+            funcId: 146,
             port: port_,
           );
         },
@@ -6657,7 +6611,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 148,
+            funcId: 147,
             port: port_,
           );
         },
@@ -6692,7 +6646,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 149,
+            funcId: 148,
             port: port_,
           );
         },
@@ -6729,7 +6683,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 150,
+            funcId: 149,
             port: port_,
           );
         },
@@ -6763,7 +6717,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 151,
+            funcId: 150,
             port: port_,
           );
         },
@@ -6799,7 +6753,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 152,
+            funcId: 151,
             port: port_,
           );
         },
@@ -6842,7 +6796,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 153,
+            funcId: 152,
             port: port_,
           );
         },
@@ -6892,7 +6846,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 154,
+            funcId: 153,
             port: port_,
           );
         },
@@ -6935,7 +6889,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 155,
+            funcId: 154,
             port: port_,
           );
         },
@@ -6984,7 +6938,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 156,
+            funcId: 155,
             port: port_,
           );
         },
@@ -7014,7 +6968,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 157,
+            funcId: 156,
             port: port_,
           );
         },
@@ -7045,7 +6999,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 158,
+            funcId: 157,
             port: port_,
           );
         },
@@ -7080,7 +7034,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 159,
+            funcId: 158,
             port: port_,
           );
         },
@@ -7123,7 +7077,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 160,
+            funcId: 159,
             port: port_,
           );
         },
@@ -7167,7 +7121,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 161,
+            funcId: 160,
             port: port_,
           );
         },
@@ -7207,7 +7161,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 162,
+            funcId: 161,
             port: port_,
           );
         },
@@ -7240,7 +7194,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 163,
+            funcId: 162,
             port: port_,
           );
         },
@@ -7277,7 +7231,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 164,
+            funcId: 163,
             port: port_,
           );
         },
@@ -7315,7 +7269,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 165,
+              funcId: 164,
               port: port_,
             );
           },
@@ -7349,7 +7303,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 166,
+              funcId: 165,
               port: port_,
             );
           },
@@ -7392,7 +7346,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 167,
+              funcId: 166,
               port: port_,
             );
           },
@@ -7436,7 +7390,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 168,
+            funcId: 167,
             port: port_,
           );
         },
@@ -7466,13 +7420,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 169,
+            funcId: 168,
             port: port_,
           );
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_bool,
-          decodeErrorData: sse_decode_AnyhowException,
+          decodeErrorData: null,
         ),
         constMeta: kCrateWalletExistsConstMeta,
         argValues: [path],
@@ -7501,7 +7455,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 170,
+            funcId: 169,
             port: port_,
           );
         },
@@ -7545,7 +7499,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 171,
+            funcId: 170,
             port: port_,
           );
         },
@@ -7575,7 +7529,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 172,
+            funcId: 171,
             port: port_,
           );
         },

--- a/lib/lib.dart
+++ b/lib/lib.dart
@@ -161,14 +161,6 @@ Future<(OperationId, String, BigInt)> sendEcash({
   amountMsats: amountMsats,
 );
 
-Future<SpendOobState> awaitEcashSend({
-  required FederationId federationId,
-  required OperationId operationId,
-}) => RustLib.instance.api.crateAwaitEcashSend(
-  federationId: federationId,
-  operationId: operationId,
-);
-
 Future<OperationId> reissueEcash({
   required FederationId federationId,
   required String ecash,

--- a/lib/request.dart
+++ b/lib/request.dart
@@ -70,23 +70,34 @@ class _RequestState extends State<Request> with SingleTickerProviderStateMixin {
   }
 
   void _waitForPayment() async {
-    await awaitReceive(
-      federationId: widget.fed.federationId,
-      operationId: widget.operationId,
-    );
-    if (mounted) {
-      Navigator.push(
-        context,
-        MaterialPageRoute(
-          builder:
-              (context) => Success(
-                lightning: true,
-                received: true,
-                amountMsats: widget.requestedAmountMsats,
-              ),
-        ),
+    try {
+      await awaitReceive(
+        federationId: widget.fed.federationId,
+        operationId: widget.operationId,
       );
-      await Future.delayed(const Duration(seconds: 4));
+      if (mounted) {
+        Navigator.push(
+          context,
+          MaterialPageRoute(
+            builder:
+                (context) => Success(
+                  lightning: true,
+                  received: true,
+                  amountMsats: widget.requestedAmountMsats,
+                ),
+          ),
+        );
+        await Future.delayed(const Duration(seconds: 4));
+      }
+    } catch (e) {
+      AppLogger.instance.error("Error occurred while receiving payment: $e");
+      ToastService().show(
+        message: "Could not receive payment",
+        duration: const Duration(seconds: 5),
+        onTap: () {},
+        icon: Icon(Icons.error),
+      );
+    } finally {
       Navigator.of(context).popUntil((route) => route.isFirst);
     }
   }

--- a/rust/carbine_fedimint/src/frb_generated.rs
+++ b/rust/carbine_fedimint/src/frb_generated.rs
@@ -42,7 +42,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.9.0";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -1459010334;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -1087282765;
 
 // Section: executor
 
@@ -6669,66 +6669,6 @@ fn wire__crate__await_ecash_reissue_impl(
         },
     )
 }
-fn wire__crate__await_ecash_send_impl(
-    port_: flutter_rust_bridge::for_generated::MessagePort,
-    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
-    rust_vec_len_: i32,
-    data_len_: i32,
-) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec, _, _, _>(
-        flutter_rust_bridge::for_generated::TaskInfo {
-            debug_name: "await_ecash_send",
-            port: Some(port_),
-            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
-        },
-        move || {
-            let message = unsafe {
-                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
-                    ptr_,
-                    rust_vec_len_,
-                    data_len_,
-                )
-            };
-            let mut deserializer =
-                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
-            let api_federation_id = <RustOpaqueMoi<
-                flutter_rust_bridge::for_generated::RustAutoOpaqueInner<FederationId>,
-            >>::sse_decode(&mut deserializer);
-            let api_operation_id = <OperationId>::sse_decode(&mut deserializer);
-            deserializer.end();
-            move |context| async move {
-                transform_result_sse::<_, flutter_rust_bridge::for_generated::anyhow::Error>(
-                    (move || async move {
-                        let mut api_federation_id_guard = None;
-                        let decode_indices_ =
-                            flutter_rust_bridge::for_generated::lockable_compute_decode_order(
-                                vec![flutter_rust_bridge::for_generated::LockableOrderInfo::new(
-                                    &api_federation_id,
-                                    0,
-                                    false,
-                                )],
-                            );
-                        for i in decode_indices_ {
-                            match i {
-                                0 => {
-                                    api_federation_id_guard =
-                                        Some(api_federation_id.lockable_decode_async_ref().await)
-                                }
-                                _ => unreachable!(),
-                            }
-                        }
-                        let api_federation_id_guard = api_federation_id_guard.unwrap();
-                        let output_ok =
-                            crate::await_ecash_send(&*api_federation_id_guard, api_operation_id)
-                                .await?;
-                        Ok(output_ok)
-                    })()
-                    .await,
-                )
-            }
-        },
-    )
-}
 fn wire__crate__await_receive_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
@@ -9304,9 +9244,9 @@ fn wire__crate__wallet_exists_impl(
             let api_path = <String>::sse_decode(&mut deserializer);
             deserializer.end();
             move |context| async move {
-                transform_result_sse::<_, flutter_rust_bridge::for_generated::anyhow::Error>(
+                transform_result_sse::<_, ()>(
                     (move || async move {
-                        let output_ok = crate::wallet_exists(api_path).await?;
+                        let output_ok = Result::<_, ()>::Ok(crate::wallet_exists(api_path).await)?;
                         Ok(output_ok)
                     })()
                     .await,
@@ -11148,65 +11088,64 @@ fn pde_ffi_dispatcher_primary_impl(
         113 => wire__crate__ack_seed_phrase_impl(port, ptr, rust_vec_len, data_len),
         114 => wire__crate__allocate_deposit_address_impl(port, ptr, rust_vec_len, data_len),
         115 => wire__crate__await_ecash_reissue_impl(port, ptr, rust_vec_len, data_len),
-        116 => wire__crate__await_ecash_send_impl(port, ptr, rust_vec_len, data_len),
-        117 => wire__crate__await_receive_impl(port, ptr, rust_vec_len, data_len),
-        118 => wire__crate__await_send_impl(port, ptr, rust_vec_len, data_len),
-        119 => wire__crate__await_withdraw_impl(port, ptr, rust_vec_len, data_len),
-        120 => wire__crate__backup_invite_codes_impl(port, ptr, rust_vec_len, data_len),
-        121 => wire__crate__balance_impl(port, ptr, rust_vec_len, data_len),
-        122 => wire__crate__calculate_withdraw_fees_impl(port, ptr, rust_vec_len, data_len),
-        123 => wire__crate__check_ecash_spent_impl(port, ptr, rust_vec_len, data_len),
-        124 => wire__crate__check_ln_address_availability_impl(port, ptr, rust_vec_len, data_len),
-        125 => wire__crate__create_multimint_from_words_impl(port, ptr, rust_vec_len, data_len),
-        126 => wire__crate__create_new_multimint_impl(port, ptr, rust_vec_len, data_len),
-        127 => wire__crate__federation_id_to_string_impl(port, ptr, rust_vec_len, data_len),
-        128 => wire__crate__federations_impl(port, ptr, rust_vec_len, data_len),
-        129 => wire__crate__get_addresses_impl(port, ptr, rust_vec_len, data_len),
-        130 => wire__crate__get_btc_price_impl(port, ptr, rust_vec_len, data_len),
-        131 => wire__crate__get_display_setting_impl(port, ptr, rust_vec_len, data_len),
-        132 => wire__crate__get_event_bus_impl(port, ptr, rust_vec_len, data_len),
-        133 => wire__crate__get_federation_meta_impl(port, ptr, rust_vec_len, data_len),
-        134 => wire__crate__get_invite_code_impl(port, ptr, rust_vec_len, data_len),
-        135 => wire__crate__get_ln_address_config_impl(port, ptr, rust_vec_len, data_len),
-        136 => wire__crate__get_max_withdrawable_amount_impl(port, ptr, rust_vec_len, data_len),
-        137 => wire__crate__get_mnemonic_impl(port, ptr, rust_vec_len, data_len),
-        138 => wire__crate__get_module_recovery_progress_impl(port, ptr, rust_vec_len, data_len),
-        139 => wire__crate__get_note_summary_impl(port, ptr, rust_vec_len, data_len),
-        140 => wire__crate__get_nwc_connection_info_impl(port, ptr, rust_vec_len, data_len),
-        141 => wire__crate__get_relays_impl(port, ptr, rust_vec_len, data_len),
-        142 => wire__crate__has_seed_phrase_ack_impl(port, ptr, rust_vec_len, data_len),
-        143 => wire__crate__insert_relay_impl(port, ptr, rust_vec_len, data_len),
-        144 => wire__crate__join_federation_impl(port, ptr, rust_vec_len, data_len),
-        145 => wire__crate__list_federations_from_nostr_impl(port, ptr, rust_vec_len, data_len),
-        146 => wire__crate__list_gateways_impl(port, ptr, rust_vec_len, data_len),
-        147 => wire__crate__list_ln_address_domains_impl(port, ptr, rust_vec_len, data_len),
-        148 => wire__crate__load_multimint_impl(port, ptr, rust_vec_len, data_len),
-        149 => wire__crate__monitor_deposit_address_impl(port, ptr, rust_vec_len, data_len),
-        150 => {
+        116 => wire__crate__await_receive_impl(port, ptr, rust_vec_len, data_len),
+        117 => wire__crate__await_send_impl(port, ptr, rust_vec_len, data_len),
+        118 => wire__crate__await_withdraw_impl(port, ptr, rust_vec_len, data_len),
+        119 => wire__crate__backup_invite_codes_impl(port, ptr, rust_vec_len, data_len),
+        120 => wire__crate__balance_impl(port, ptr, rust_vec_len, data_len),
+        121 => wire__crate__calculate_withdraw_fees_impl(port, ptr, rust_vec_len, data_len),
+        122 => wire__crate__check_ecash_spent_impl(port, ptr, rust_vec_len, data_len),
+        123 => wire__crate__check_ln_address_availability_impl(port, ptr, rust_vec_len, data_len),
+        124 => wire__crate__create_multimint_from_words_impl(port, ptr, rust_vec_len, data_len),
+        125 => wire__crate__create_new_multimint_impl(port, ptr, rust_vec_len, data_len),
+        126 => wire__crate__federation_id_to_string_impl(port, ptr, rust_vec_len, data_len),
+        127 => wire__crate__federations_impl(port, ptr, rust_vec_len, data_len),
+        128 => wire__crate__get_addresses_impl(port, ptr, rust_vec_len, data_len),
+        129 => wire__crate__get_btc_price_impl(port, ptr, rust_vec_len, data_len),
+        130 => wire__crate__get_display_setting_impl(port, ptr, rust_vec_len, data_len),
+        131 => wire__crate__get_event_bus_impl(port, ptr, rust_vec_len, data_len),
+        132 => wire__crate__get_federation_meta_impl(port, ptr, rust_vec_len, data_len),
+        133 => wire__crate__get_invite_code_impl(port, ptr, rust_vec_len, data_len),
+        134 => wire__crate__get_ln_address_config_impl(port, ptr, rust_vec_len, data_len),
+        135 => wire__crate__get_max_withdrawable_amount_impl(port, ptr, rust_vec_len, data_len),
+        136 => wire__crate__get_mnemonic_impl(port, ptr, rust_vec_len, data_len),
+        137 => wire__crate__get_module_recovery_progress_impl(port, ptr, rust_vec_len, data_len),
+        138 => wire__crate__get_note_summary_impl(port, ptr, rust_vec_len, data_len),
+        139 => wire__crate__get_nwc_connection_info_impl(port, ptr, rust_vec_len, data_len),
+        140 => wire__crate__get_relays_impl(port, ptr, rust_vec_len, data_len),
+        141 => wire__crate__has_seed_phrase_ack_impl(port, ptr, rust_vec_len, data_len),
+        142 => wire__crate__insert_relay_impl(port, ptr, rust_vec_len, data_len),
+        143 => wire__crate__join_federation_impl(port, ptr, rust_vec_len, data_len),
+        144 => wire__crate__list_federations_from_nostr_impl(port, ptr, rust_vec_len, data_len),
+        145 => wire__crate__list_gateways_impl(port, ptr, rust_vec_len, data_len),
+        146 => wire__crate__list_ln_address_domains_impl(port, ptr, rust_vec_len, data_len),
+        147 => wire__crate__load_multimint_impl(port, ptr, rust_vec_len, data_len),
+        148 => wire__crate__monitor_deposit_address_impl(port, ptr, rust_vec_len, data_len),
+        149 => {
             wire__crate__parse_scanned_text_for_federation_impl(port, ptr, rust_vec_len, data_len)
         }
-        151 => wire__crate__parsed_scanned_text_impl(port, ptr, rust_vec_len, data_len),
-        152 => wire__crate__payment_preview_impl(port, ptr, rust_vec_len, data_len),
-        153 => wire__crate__receive_impl(port, ptr, rust_vec_len, data_len),
-        154 => wire__crate__recheck_address_impl(port, ptr, rust_vec_len, data_len),
-        155 => wire__crate__register_ln_address_impl(port, ptr, rust_vec_len, data_len),
-        156 => wire__crate__reissue_ecash_impl(port, ptr, rust_vec_len, data_len),
-        157 => wire__crate__rejoin_from_backup_invites_impl(port, ptr, rust_vec_len, data_len),
-        158 => wire__crate__remove_relay_impl(port, ptr, rust_vec_len, data_len),
-        159 => wire__crate__select_receive_gateway_impl(port, ptr, rust_vec_len, data_len),
-        160 => wire__crate__send_impl(port, ptr, rust_vec_len, data_len),
-        161 => wire__crate__send_ecash_impl(port, ptr, rust_vec_len, data_len),
-        162 => wire__crate__send_lnaddress_impl(port, ptr, rust_vec_len, data_len),
-        163 => wire__crate__set_display_setting_impl(port, ptr, rust_vec_len, data_len),
-        164 => wire__crate__set_nwc_connection_info_impl(port, ptr, rust_vec_len, data_len),
-        165 => wire__crate__subscribe_deposits_impl(port, ptr, rust_vec_len, data_len),
-        166 => wire__crate__subscribe_multimint_events_impl(port, ptr, rust_vec_len, data_len),
-        167 => wire__crate__subscribe_recovery_progress_impl(port, ptr, rust_vec_len, data_len),
-        168 => wire__crate__transactions_impl(port, ptr, rust_vec_len, data_len),
-        169 => wire__crate__wallet_exists_impl(port, ptr, rust_vec_len, data_len),
-        170 => wire__crate__wallet_summary_impl(port, ptr, rust_vec_len, data_len),
-        171 => wire__crate__withdraw_to_address_impl(port, ptr, rust_vec_len, data_len),
-        172 => wire__crate__word_list_impl(port, ptr, rust_vec_len, data_len),
+        150 => wire__crate__parsed_scanned_text_impl(port, ptr, rust_vec_len, data_len),
+        151 => wire__crate__payment_preview_impl(port, ptr, rust_vec_len, data_len),
+        152 => wire__crate__receive_impl(port, ptr, rust_vec_len, data_len),
+        153 => wire__crate__recheck_address_impl(port, ptr, rust_vec_len, data_len),
+        154 => wire__crate__register_ln_address_impl(port, ptr, rust_vec_len, data_len),
+        155 => wire__crate__reissue_ecash_impl(port, ptr, rust_vec_len, data_len),
+        156 => wire__crate__rejoin_from_backup_invites_impl(port, ptr, rust_vec_len, data_len),
+        157 => wire__crate__remove_relay_impl(port, ptr, rust_vec_len, data_len),
+        158 => wire__crate__select_receive_gateway_impl(port, ptr, rust_vec_len, data_len),
+        159 => wire__crate__send_impl(port, ptr, rust_vec_len, data_len),
+        160 => wire__crate__send_ecash_impl(port, ptr, rust_vec_len, data_len),
+        161 => wire__crate__send_lnaddress_impl(port, ptr, rust_vec_len, data_len),
+        162 => wire__crate__set_display_setting_impl(port, ptr, rust_vec_len, data_len),
+        163 => wire__crate__set_nwc_connection_info_impl(port, ptr, rust_vec_len, data_len),
+        164 => wire__crate__subscribe_deposits_impl(port, ptr, rust_vec_len, data_len),
+        165 => wire__crate__subscribe_multimint_events_impl(port, ptr, rust_vec_len, data_len),
+        166 => wire__crate__subscribe_recovery_progress_impl(port, ptr, rust_vec_len, data_len),
+        167 => wire__crate__transactions_impl(port, ptr, rust_vec_len, data_len),
+        168 => wire__crate__wallet_exists_impl(port, ptr, rust_vec_len, data_len),
+        169 => wire__crate__wallet_summary_impl(port, ptr, rust_vec_len, data_len),
+        170 => wire__crate__withdraw_to_address_impl(port, ptr, rust_vec_len, data_len),
+        171 => wire__crate__word_list_impl(port, ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }

--- a/rust/carbine_fedimint/src/lib.rs
+++ b/rust/carbine_fedimint/src/lib.rs
@@ -157,13 +157,18 @@ pub async fn create_multimint_from_words(path: String, words: Vec<String>) {
 }
 
 #[frb]
-pub async fn wallet_exists(path: String) -> anyhow::Result<bool> {
-    let db_path = PathBuf::from_str(&path)?.join("client.db");
-    let db: Database = RocksDb::open(db_path).await?.into();
+pub async fn wallet_exists(path: String) -> bool {
+    let db_path = PathBuf::from_str(&path)
+        .expect("Invalid application directory for wallet")
+        .join("client.db");
+    let db: Database = RocksDb::open(db_path)
+        .await
+        .expect("Could not open database")
+        .into();
     if let Ok(_) = Client::load_decodable_client_secret::<Vec<u8>>(&db).await {
-        Ok(true)
+        true
     } else {
-        Ok(false)
+        false
     }
 }
 
@@ -407,17 +412,6 @@ pub async fn send_ecash(
 ) -> anyhow::Result<(OperationId, String, u64)> {
     let multimint = get_multimint();
     multimint.send_ecash(federation_id, amount_msats).await
-}
-
-#[frb]
-pub async fn await_ecash_send(
-    federation_id: &FederationId,
-    operation_id: OperationId,
-) -> anyhow::Result<SpendOOBState> {
-    let multimint = get_multimint();
-    multimint
-        .await_ecash_send(federation_id, operation_id)
-        .await
 }
 
 async fn parse_ecash(federation_id: &FederationId, ecash: String) -> anyhow::Result<u64> {


### PR DESCRIPTION
Working towards: https://github.com/fedimint/fedimint-app/issues/43

 - Makes `wallet_exists` panic instead of return result
 - Removes `await_ecash_send`, we don't use it anywhere
 - Adds try/catch around `selectReceiveGateway` and `receive`
 - Adds try/catch around `awaitReceive`
 - Adds try/catch around `walletSummary`